### PR TITLE
fix(automerge): set MERGE_METHOD=squash to match commons policy

### DIFF
--- a/.github/workflows/reusable-automerge.yaml
+++ b/.github/workflows/reusable-automerge.yaml
@@ -18,3 +18,10 @@ jobs:
         uses: pascalgn/automerge-action@v0.16.4
         env:
           GITHUB_TOKEN: ${{ secrets.token  }}
+          # Match the repo-level `allow_squash_merge: true` +
+          # `allow_merge_commit: false` convention declared by
+          # commons-settings.yml. Without this override the action
+          # defaults to MERGE_METHOD=merge, which GitHub rejects because
+          # merge commits are disabled, and the action exits 0 without
+          # actually merging — a silent no-op that looks green in CI.
+          MERGE_METHOD: squash


### PR DESCRIPTION
## Summary

Override pascalgn/automerge-action's default \`MERGE_METHOD=merge\` with
\`squash\` in the reusable-automerge workflow, so it aligns with the
repo-level \`allow_squash_merge: true\` + \`allow_merge_commit: false\`
policy declared by \`commons-settings.yml\`.

## Changes

- \`.github/workflows/reusable-automerge.yaml\`: add \`MERGE_METHOD: squash\`
  to the action's env; inline comment explains the why

## Linked issues

None — finding originated from two independent observations in a
consumer repo.

## Testing

- Observed locally: \`claude-shared\` PR #13 and PR #14 both completed the
  \`automerge / automerge\` status check as SUCCESS but neither was
  actually merged; both had to land via \`gh pr merge --squash --auto\`
- With this change, the action will call GitHub's merge API with
  \`merge_method=squash\` which the repo accepts, so the merge completes

## Risk / rollout notes

- Minor-version change to a portfolio-wide reusable workflow. Every
  consumer of \`reusable-automerge.yaml\` picks this up on the next tag
  bump in their \`uses:\` pin.
- A consumer whose repo policy differs (e.g. \`allow_squash_merge: false\`
  + \`allow_merge_commit: true\`) would regress. Spot-check: every repo in
  the \`nolte\` portfolio extends \`commons-settings.yml\` which sets the
  squash policy, so no regressions expected.
- If a future consumer needs a different merge method, the right fix is
  to expose \`MERGE_METHOD\` as a workflow input, not to revert this
  default.