### PR TITLE
chore(labels): add conventional-commits type + area labels

### DIFF
--- a/.github/commons-settings.yml
+++ b/.github/commons-settings.yml
@@ -53,6 +53,18 @@ labels:
     color: "#6e70ef"
     description: Maintenance
 
+  - name: fix
+    color: "#d73a4a"
+    description: Conventional Commits type `fix` — bug fix.
+
+  - name: feat
+    color: "#a2eeef"
+    description: Conventional Commits type `feat` — new feature.
+
+  - name: docs
+    color: "#0075ca"
+    description: Conventional Commits type `docs` — documentation or spec change.
+
   - name: question
     color: "#3ffc8a"
     description: User question
@@ -89,9 +101,21 @@ labels:
     color: "#19F700"
     description: "Allow automatic Merge."
 
-  - name: project-config
-    color: "#ed979d"
-    description: "GitHub Project Configuration change."
+  - name: spec
+    color: "#c5def5"
+    description: Touches files under `spec/`.
+
+  - name: skills
+    color: "#bfdadc"
+    description: Touches files under `skills/`.
+
+  - name: agents
+    color: "#c2e0c6"
+    description: Touches files under `agents/`.
+
+  - name: claude-code
+    color: "#ffd33d"
+    description: Touches Claude Code integration (`.claude/`, `.claude-plugin/`, `CLAUDE.md`).
 
 # <!--td-commons-settings-labels-end-->
 


### PR DESCRIPTION
## Summary

Extend the portfolio label set in \`commons-settings.yml\` so the
Conventional-Commits type of every PR and the touched area of its diff
have an explicit matching label. Consumers following the
\`pull-request-merge\` skill in \`nolte-shared\` expect these candidates,
and their absence was recorded as a portfolio gap on every merge
through that skill.

## Changes

- Add type labels: \`fix\`, \`feat\`, \`docs\`
- Add area labels: \`spec\`, \`skills\`, \`agents\`, \`claude-code\`
- Remove duplicate \`project-config\` entry at the bottom of the list
- Leave existing labels (\`chore\`, \`documentations\`, \`cicd\`, etc.)
  untouched so consumer PRs already tagged with them stay valid

## Linked issues

None — finding originated from portfolio-gap observations on
\`claude-shared\` PRs #13 and #14.

## Testing

- YAML lint: the file parses cleanly (no new structural keys)
- Probot Settings app applies \`commons-settings.yml\` via the \`_extends:\`
  mechanism; after this PR lands, consumers re-sync picks the new
  labels up automatically on the next settings-app run

## Risk / rollout notes

Low risk — label additions are additive. A consumer repo that happens
to already define one of the new names locally would collide, but a
portfolio sweep shows no existing local definitions of \`fix\`, \`feat\`,
\`docs\`, \`spec\`, \`skills\`, \`agents\`, or \`claude-code\` in any
\`nolte\`-owned repo. The duplicate \`project-config\` removal is a
no-op fix (GitHub picked only the last entry anyway).