### PR TITLE
fix(release): drop targetCommitish from gh release list calls

### DIFF
--- a/.github/workflows/reusable-release-drafter.yml
+++ b/.github/workflows/reusable-release-drafter.yml
@@ -27,8 +27,10 @@ jobs:
           start_marker='<!-- release-skill-layer:project-context-start -->'
           end_marker='<!-- release-skill-layer:project-context-end -->'
 
+          # gh release list on the runner CLI does not expose targetCommitish;
+          # we only need tagName here, the restore step re-resolves the active draft.
           draft=$(gh release list --repo "$REPO" \
-            --json isDraft,tagName,targetCommitish \
+            --json isDraft,tagName \
             --jq '[.[] | select(.isDraft == true)] | .[0]')
 
           if [[ -z "$draft" || "$draft" == "null" ]]; then

--- a/.github/workflows/reusable-release-publish.yml
+++ b/.github/workflows/reusable-release-publish.yml
@@ -47,7 +47,9 @@ jobs:
           TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          drafts=$(gh release list --json isDraft,tagName,targetCommitish --jq '[.[] | select(.isDraft == true)]')
+          # gh release list on the runner CLI does not expose targetCommitish;
+          # resolve the target via gh release view per matching tag.
+          drafts=$(gh release list --json isDraft,tagName --jq '[.[] | select(.isDraft == true)]')
           total=$(echo "$drafts" | jq 'length')
 
           if [[ "$total" == "0" ]]; then
@@ -60,7 +62,7 @@ jobs:
 
           if [[ "$match_count" == "0" ]]; then
             echo "::error::No draft release with tag '$TAG'. Open drafts:"
-            echo "$drafts" | jq -r '.[] | "  - \(.tagName) (target: \(.targetCommitish))"' >&2
+            echo "$drafts" | jq -r '.[] | "  - \(.tagName)"' >&2
             exit 1
           fi
 
@@ -69,7 +71,7 @@ jobs:
             exit 1
           fi
 
-          target=$(echo "$match" | jq -r '.[0].targetCommitish')
+          target=$(gh release view "$TAG" --json targetCommitish --jq .targetCommitish)
           if [[ "$target" == refs/heads/* ]]; then
             sha=$(git rev-parse "origin/${target#refs/heads/}")
           else


### PR DESCRIPTION
## Summary

Smoke-test of #326+#327 on the unreleased commits (`9e39b97` + `b955ede`) hit a runner-CLI compatibility issue:

```
Unknown JSON field: "targetCommitish"
Available fields: createdAt, isDraft, isImmutable, isLatest,
                  isPrerelease, name, publishedAt, tagName
```

The runner's `gh` exposes `targetCommitish` only on `gh release view`, not on `gh release list`. Both new reusables used the `list --json …,targetCommitish` form.

## Fix

- **`reusable-release-drafter.yml`** — drop `targetCommitish` from the capture-step query; the field was actually unused (only `tagName` was consumed; the restore step re-resolves the active draft).
- **`reusable-release-publish.yml`** — keep `gh release list` to enumerate open drafts and match by `tagName`, then resolve the target SHA via a separate `gh release view "$TAG" --json targetCommitish`. Also drops the now-superfluous "(target: …)" suffix from the multi-draft error message because we no longer pre-fetch that value for every draft.

## Test plan

- [ ] CI green
- [ ] After merge, re-run smoke test:
  - `gh workflow run release-drafter.yml --ref develop` should produce a fresh draft for the unreleased commits without erroring on the capture step.
  - `gh workflow run release-publish.yml --ref develop -f tag=<draft-tag> -f dry_run=true` should pass all gates.

## Triage classification

`defect` per `spec/project/workflow-health/` §Triage before remediation — runner-CLI compatibility issue introduced by my own #326/#327 PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)