### PR TITLE
fix(release): add workflow_dispatch escape hatch to refresh-master

### DIFF
--- a/.github/workflows/release-cd-refresh-master.yml
+++ b/.github/workflows/release-cd-refresh-master.yml
@@ -1,9 +1,23 @@
+name: Release Deliver to Master
+
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: |
+          Tag to fast-forward master to (e.g. v1.1.15). Use as a manual
+          escape hatch when the release:published cascade did not fire
+          under GITHUB_TOKEN — see spec/project/workflow-health/
+          §Known platform constraints.
+        required: true
+        type: string
 
 jobs:
   refresh_presentation_branch:
     uses: nolte/gh-plumbing/.github/workflows/reusable-release-cd-refresh-master.yml@develop
+    with:
+      from_branch: ${{ inputs.tag || github.event.ref }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

`release-publish.yml` (landed in #326) publishes releases under `GITHUB_TOKEN`. The resulting `release: published` event does not cascade to other workflows — deterministic platform behaviour per `spec/project/workflow-health/` §Known platform constraints. Result: `release-cd-refresh-master.yml` never fires after a `release-publish.yml` dispatch, and `master` stays stale.

Surfaced live during the smoke-test publish of `v1.1.15`: the publish workflow ran green, the release flipped to non-draft, but no `release-cd-refresh-master.yml` run started; `master` is still pointing at `v1.1.14`'s merge commit.

## Fix

Add `workflow_dispatch` as a manual escape hatch on the consumer wrapper:

- New required `tag` input (e.g. `v1.1.15`) so the dispatch is explicit per `release-automation` §Operational contract (no "newest wins" heuristic).
- `from_branch` is now always set explicitly via `${{ inputs.tag || github.event.ref }}`, falling through to `github.event.ref` for the natural release path so behaviour is unchanged for events that DO cascade (UI publish, future App-token publish).

The reusable workflow itself is untouched.

## Companion adoption note

Once this lands, the manual escape hatch for the cascade gap is:

```
gh workflow run release-cd-refresh-master.yml --ref develop -f tag=v1.1.15
```

This is the recommended `workflow-health` SHOULD-bullet workaround until the portfolio App/PAT remediation ships (Phase 3). Downstream consumer repos that adopt this wrapper inherit the same escape hatch.

## Test plan

- [ ] CI green
- [ ] After merge, dispatch `release-cd-refresh-master.yml` for `v1.1.15` and confirm `master` fast-forwards from `613691b` to `v1.1.15`'s commit (`6af10e9`)
- [ ] Run shows the workflow consumed `inputs.tag` correctly (no fallthrough error)

## Out of scope

- The portfolio App/PAT remediation that would make the cascade fire automatically (Phase 3 of the release-process refactor) — separate, larger effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)