### PR TITLE
chore(automerge): delete source branch after successful squash

### DIFF
--- a/.github/workflows/reusable-automerge.yaml
+++ b/.github/workflows/reusable-automerge.yaml
@@ -25,3 +25,11 @@ jobs:
           # merge commits are disabled, and the action exits 0 without
           # actually merging — a silent no-op that looks green in CI.
           MERGE_METHOD: squash
+          # `pascalgn/automerge-action` does not honour the GitHub-native
+          # `delete_branch_on_merge: true` repo setting; it has its own
+          # `MERGE_DELETE_BRANCH` env var that defaults to false. Setting
+          # it to "true" makes the action delete the source branch as
+          # part of the same call, mirroring the repo-level convention
+          # declared by commons-settings.yml and removing the per-PR
+          # `gh api -X DELETE` catch-up step from consumer workflows.
+          MERGE_DELETE_BRANCH: "true"


### PR DESCRIPTION
## Summary

`pascalgn/automerge-action` does not honour the GitHub-native `delete_branch_on_merge: true` repo setting; it has its own `MERGE_DELETE_BRANCH` env var that defaults to `false`. As a consequence, every consumer of `reusable-automerge.yaml` (`nolte/claude-shared`, `nolte/kamerplanter`, …) currently leaves the source branch behind after a successful squash-merge, requiring a per-PR catch-up `gh api -X DELETE` call. This PR sets `MERGE_DELETE_BRANCH: "true"` in the reusable workflow so the action deletes the source branch as part of the same call, mirroring the repo-level convention declared by `commons-settings.yml`.

## Changes

- `.github/workflows/reusable-automerge.yaml`: add `MERGE_DELETE_BRANCH: "true"` to the action's env block, with a comment explaining why the GitHub-native setting alone is insufficient. The existing `MERGE_METHOD: squash` override stays in place.

## Linked issues

None

## Testing

- The next consumer-repo squash-merge that runs against this reusable workflow's release tag will be the live test. Concrete consumer-side evidence motivating this change: PRs #28, #29, #30, #32, #33 in `nolte/claude-shared` all required the same `gh api -X DELETE` catch-up step despite `commons-settings.yml`'s `delete_branch_on_merge: true`.
- No syntactic or schema change beyond the new env entry; the action's behaviour is otherwise unchanged.

## Risk / rollout notes

Low. The change only affects what `pascalgn/automerge-action` does *after* a successful merge. After this lands, consumer repos must pin to the new release tag (existing `gh-plumbing` release-tag-pin requirement) to pick up the fix. Until then, the manual catch-up step stays operational on the current pin.