### PR TITLE
chore(settings): trigger Probot sync; document _extends propagation gap

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,5 +1,11 @@
 ---
-# These settings are synced to GitHub by https://probot.github.io/apps/settings/
+# These settings are synced to GitHub by https://probot.github.io/apps/settings/.
+#
+# The Probot Settings App reacts to push events that touch THIS file; changes
+# to the upstream `_extends:` source (`commons-settings.yml`) do not trigger a
+# fresh sync on their own. When a commons change should propagate, edit this
+# file as well (a comment touch is enough) so the App re-runs the merge.
+# Tracked by https://github.com/nolte/gh-plumbing/issues/331.
 
 _extends: gh-plumbing:.github/commons-settings.yml
 


### PR DESCRIPTION
## Summary

Investigates and resolves the immediate symptom of #331: 8 labels declared in `.github/commons-settings.yml` since PR #324 (2026-04-24) are missing from the live repo as of 2026-05-01.

## Root cause

The Probot Settings App reacts to **push events that touch `.github/settings.yml`**. It does not re-sync when the upstream `_extends:` source (`commons-settings.yml`) changes by itself. `git log --follow .github/settings.yml` shows the last touch was in the initial-commits in 2021 — meaning no sync has fired in this repo since the App-install era, regardless of how many commons changes have landed.

This is an architectural gap of the `_extends:` mechanism, not a defect of the App. Documented inline so the next maintainer doesn't re-discover it.

## Fix

A no-op comment-touch of `.github/settings.yml` to produce a push event that the App actually processes. The comment also captures the propagation-gap lesson and cross-links to #331.

## Acceptance criteria

After merge:

- [ ] `gh label list --repo nolte/gh-plumbing | sort` includes `docs`, `feat`, `fix`, `spec`, `skills`, `agents`, `claude-code`, `release`
- [ ] If labels still don't appear, the App is broken/uninstalled — escalate per `workflow-health` §Probot app availability (the issue's other investigation steps then apply: verify install, check webhook delivery history)

## Test plan

- [ ] CI green
- [ ] Run `gh label list --repo nolte/gh-plumbing` post-merge to verify the 8 missing labels are now present (max 1–2 minutes after merge based on App's typical reaction time)

## Companion observations

- The naming-drift items (`documentations` vs `documentation`, `github_actions` vs `github-actions`) are separate from this sync trigger and remain open per #331's "Related naming-drift items" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)