### PR TITLE
chore(labels): close drift items in commons-settings and trigger sync

### DIFF
--- a/.github/commons-boring-cyborg.yml
+++ b/.github/commons-boring-cyborg.yml
@@ -7,7 +7,7 @@ labelPRBasedOnFilePath:
     - .github/settings.yml
   chore:
     - .github/**
-  documentations:
+  documentation:
     - docs/**
     - mkdocs.yml
     - .github/ISSUE_TEMPLATE/**

--- a/.github/commons-settings.yml
+++ b/.github/commons-settings.yml
@@ -69,9 +69,9 @@ labels:
     color: "#3ffc8a"
     description: User question
 
-  - name: documentations
+  - name: documentation
     color: "#caa7e8"
-    description: Update documentation
+    description: Update documentation.
 
   - name: cicd
     color: "#fbca04"
@@ -119,7 +119,15 @@ labels:
 
   - name: release
     color: "#5319e7"
-    description: "Conventional Commits subject `chore(release): <tag>` — version-alignment PR; excluded from release-drafter changelog."
+    description: Version-alignment PR — excluded from release-drafter changelog.
+
+  - name: github-actions
+    color: "#000000"
+    description: Touches GitHub Actions workflows under `.github/workflows/`.
+
+  - name: stale
+    color: "#cccccc"
+    description: Auto-applied by actions/stale to inactive issues and pull requests.
 
 # <!--td-commons-settings-labels-end-->
 

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -6,6 +6,10 @@
 # fresh sync on their own. When a commons change should propagate, edit this
 # file as well (a comment touch is enough) so the App re-runs the merge.
 # Tracked by https://github.com/nolte/gh-plumbing/issues/331.
+#
+# Last propagation: 2026-05-01 — drift cleanup (rename `documentations` →
+# `documentation`, add `stale` and `github-actions`, simplify `release`
+# description).
 
 _extends: gh-plumbing:.github/commons-settings.yml
 


### PR DESCRIPTION
## Summary

Bundles four label-portfolio drift items in one Probot Settings App sync wave, closing the remaining work on #331.

### Changes

| Item | Action | Why |
|---|---|---|
| `documentations` (with trailing `s`) | Rename → `documentation` | Match the `pull-request-merge` skill's `documentation` candidate. boring-cyborg routing updated in lockstep. |
| `github-actions` (hyphen form) | Add | Match the skill's `github-actions` candidate for paths under `.github/workflows/`. Coexists with the existing `cicd` label that boring-cyborg routes to. |
| `stale` | Add | Probot owns it explicitly so actions/stale's lazy-create doesn't get reaped on every commons sync. |
| `release` description | Simplify | Drop `<tag>` angle brackets and the embedded colon. **Hypothesis from #333 sync:** those characters are why `release` was the only declared-but-not-synced label after PR #333 hit Probot. Verifiable by `gh label list` post-merge. |

`.github/settings.yml` gets a one-line touch so the Probot App re-runs (the lesson from #333: commons changes alone don't propagate).

## Side effects

- The `documentations` label disappears from historical references on closed PRs/issues; `documentation` appears on new ones from this PR forward. Cosmetic only.
- New `github-actions` and `stale` labels start unattached and grow organically; no migration of existing PRs/issues.

## Acceptance criteria for #331

After merge:

- [ ] `gh label list --repo nolte/gh-plumbing` includes `release`, `documentation`, `github-actions`, `stale`
- [ ] `gh label list` does **not** include `documentations` (singular form took over)
- [ ] If `release` STILL doesn't appear, the angle-brackets / colon hypothesis is wrong; need to investigate webhook delivery history
- [ ] All 8 originally-declared-but-missing labels from the snapshot in #331 are now live (the 7 that synced via #333 plus `release`)

## Test plan

- [ ] CI green
- [ ] After merge, run `gh label list --repo nolte/gh-plumbing | sort` and diff against the expected set
- [ ] Confirm next PR with title prefix matching `chore:` or `feat:` etc. picks up the corresponding type label automatically (skill candidate now has a target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)