### PR TITLE
chore(pre-commit): validate label description length ≤100 chars

### DIFF
--- a/.github/scripts/check-label-descriptions.py
+++ b/.github/scripts/check-label-descriptions.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Validate that label descriptions in commons-settings.yml stay within
+GitHub's 100-character limit.
+
+Exceeding the limit causes the GitHub label API to reject the request
+with HTTP 422 ("description is too long"); the Probot Settings App
+swallows that error silently and the rest of the sync continues, so the
+offending label never appears in the live repo. Discovered while closing
+issue #331; see `.github/settings.yml` header comment and the auto-memory
+`reference_label_portfolio_gaps.md` for the full context.
+"""
+
+import sys
+from pathlib import Path
+
+import yaml
+
+LIMIT = 100
+
+
+def check(path: Path) -> list[str]:
+    data = yaml.safe_load(path.read_text()) or {}
+    errors: list[str] = []
+    for label in data.get("labels", []):
+        desc = label.get("description") or ""
+        if len(desc) > LIMIT:
+            errors.append(
+                f"  {path}: label '{label.get('name')}' description is "
+                f"{len(desc)} chars (max {LIMIT})"
+            )
+    return errors
+
+
+def main(argv: list[str]) -> int:
+    errors: list[str] = []
+    for arg in argv[1:]:
+        errors.extend(check(Path(arg)))
+    if errors:
+        print(
+            "Label descriptions over GitHub's 100-character limit "
+            "(would silently skip during Probot sync, see issue #331):",
+            file=sys.stderr,
+        )
+        for e in errors:
+            print(e, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,11 @@ repos:
           - id: end-of-file-fixer
           - id: trailing-whitespace
             args: ['--markdown-linebreak-ext=md']
+    - repo: local
+      hooks:
+          - id: label-description-length
+            name: Label descriptions ≤100 chars (GitHub API limit, see #331)
+            entry: .github/scripts/check-label-descriptions.py
+            language: python
+            additional_dependencies: ['pyyaml']
+            files: '^\.github/commons-settings\.yml$'


### PR DESCRIPTION
## Summary

Adds a pre-commit hook that validates `.github/commons-settings.yml` label descriptions against GitHub's silent 100-character limit.

## Background

GitHub's label API rejects descriptions longer than 100 characters with HTTP 422 ("description is too long"). The Probot Settings App swallows that error and continues the rest of the sync run, so the offending label silently never appears in the live repo. Discovered during issue #331 closure:

- PR #326 added `release` with a 117-character description.
- PR #333's sync wave skipped `release` silently while syncing 7 other labels.
- PR #335 shortened the description; the next sync recovered.

That's a class of bug ("declared but never lives") that's only visible by running `gh label list` and diffing against `commons-settings.yml`. A pre-commit gate keeps it from re-occurring.

## Implementation

- **`.github/scripts/check-label-descriptions.py`** — small stdlib + PyYAML script. For each entry under `labels:` in the input file, fail with the label name and length when `description` > 100. Exits 0 otherwise.
- **`.pre-commit-config.yaml`** — adds a `local` hook scoped via `files: '^\.github/commons-settings\.yml$'` so unrelated YAML edits don't trigger it. `additional_dependencies: [pyyaml]` so the venv has what the script needs.

Verified locally:
- Positive run on the current `commons-settings.yml` — `Passed`.
- Negative run with a synthetic 117-char description — fails with the expected error format.

## Test plan

- [ ] CI green
- [ ] Future PRs that touch `commons-settings.yml` with a too-long description fail at pre-commit time

## Out of scope

- Validating `commons-boring-cyborg.yml` or `commons-release-drafter.yml` against label-name references — separate consistency-check that's worth a follow-up Issue if the labels-vs-routing churn becomes a recurring theme.
- Converting the script into a published pre-commit-hooks repo for portfolio reuse — only one consumer today; revisit if a second gh-plumbing-style repo emerges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)