### PR TITLE
chore(static-tests): add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/build-static-tests.yaml
+++ b/.github/workflows/build-static-tests.yaml
@@ -1,5 +1,6 @@
 on:
   push:
+  workflow_dispatch:
 
 jobs:
   static:


### PR DESCRIPTION
## Summary

Add `workflow_dispatch:` to `build-static-tests.yaml` so the required check `static / Static CI Tests` can be manually triggered on `develop`. Needed because the existing `on: push:` trigger doesn't fire after a `pascalgn/automerge-action` squash-merge under `GITHUB_TOKEN`, leaving `develop`'s tip without the required check and blocking `release-publish.yml` dispatch under the release-skill-layer gate 2d.

## Changes

- `.github/workflows/build-static-tests.yaml`: add `workflow_dispatch:` next to the existing `push:` trigger.

## Linked issues

None

## Testing

- Local pre-commit (check-yaml, trim-trailing-whitespace, fix-end-of-files, label-descriptions) — green.
- Post-merge: operator dispatches the workflow on `develop` via `gh workflow run build-static-tests.yaml --ref develop` and confirms `conclusion=success`.

## Risk / rollout notes

Low. Additive trigger only — `push:` behaviour stays unchanged. The change is reversible by removing the line. Downstream effect: any operator can now manually run the static-tests bundle on any ref, which is acceptable per the workflow's read-only nature (the called reusable workflows produce no merge / push side effects).

This is the minimum-impact unblock for the v1.1.16 release on this repo. The long-term portfolio fix is migrating `pascalgn/automerge-action` from `GITHUB_TOKEN` to an App-installation token so downstream workflows cascade naturally; that fix is intentionally out of scope here.