### PR TITLE
fix(workflows): remove unevaluatable expression from reusable-docker-publish description

### DIFF
--- a/.github/workflows/reusable-docker-publish.yaml
+++ b/.github/workflows/reusable-docker-publish.yaml
@@ -6,7 +6,9 @@ on:
       image_name:
         description: |
           Image name under ghcr.io/<owner>/. The full reference becomes
-          ghcr.io/${{ github.repository_owner }}/<image_name>:<tag>.
+          ghcr.io/<repository_owner>/<image_name>:<tag>, where
+          <repository_owner> is resolved at job time via
+          github.repository_owner.
         required: true
         type: string
       context:


### PR DESCRIPTION
## Summary

`reusable-docker-publish.yaml` declares `inputs.image_name.description` with
an inline `${{ github.repository_owner }}` expression. GitHub Actions
evaluates `${{ }}` expressions in `workflow_call` input descriptions at
workflow-validation time, where the `github` context is not in scope, so
any consumer that calls this reusable via `workflow_dispatch` fails to
parse the workflow. This PR replaces the inline expression with a literal
placeholder.

## Changes

- `.github/workflows/reusable-docker-publish.yaml`: rewrite the
  `image_name` description to use a literal `<repository_owner>`
  placeholder plus a clarifying note. The actual
  `${{ github.repository_owner }}` reference in
  `steps.meta.with.images` is **not** touched — that one runs at job
  time where the `github` context is available.

## Linked issues

None. Defect surfaced via downstream dispatch from
`nolte/reachy-mini-mcp` `release-cd-deliver-docker.yml`.

## Testing

Reproducer (before fix):

```
gh workflow run release-cd-deliver-docker.yml --ref develop --repo nolte/reachy-mini-mcp
# => HTTP 422: Invalid Argument - failed to parse workflow:
#    Unrecognized named-value: 'github'.
#    Located at position 1 within expression: github.repository_owner
```

After merging this PR, the consumer dispatch will parse and run.

## Risk / rollout notes

- Documentation-only change inside an input description. No behaviour
  change at job time; the build/push pipeline is untouched.
- No version bump needed (description text only, no schema or input
  shape change).
- Once merged, downstream consumers pinned at `@develop` pick this up
  automatically. Tag-pinned consumers (`@v1.1.16` etc.) will pick it up
  on the next release of `nolte/gh-plumbing`.