### PR TITLE
fix(settings): make develop branch protection portfolio-neutral

### DIFF
--- a/.github/commons-settings.yml
+++ b/.github/commons-settings.yml
@@ -147,7 +147,12 @@ branches:
     protection:
       required_pull_request_reviews: null
       required_status_checks:
+        # Portfolio-default leaves required contexts empty so this commons
+        # config does not impose a gh-plumbing-specific check name on every
+        # consumer repo. Consumers MUST declare their own required-check
+        # contexts in their per-repo .github/settings.yml. See
+        # spec/project/pull-request-workflow §required status checks.
         strict: true
-        contexts:
-          - "static / Static CI Tests"
+        contexts: []
+      enforce_admins: true
       restrictions: null


### PR DESCRIPTION
## Summary

The commons-settings.yml \`develop\` branch-protection block had two
issues that surfaced while applying it to \`nolte/reachy-mini-mcp\`:

1. \`required_status_checks.contexts\` hardcoded \`static / Static CI Tests\`
   — a check name only present in this repo. Any consumer that syncs
   the Probot Settings App would inherit a non-existent required check
   and have every PR blocked from merging.
2. \`enforce_admins\` was set on \`master\` but missing on \`develop\`,
   despite \`spec/project/pull-request-workflow/\` stating that
   \`enforce_admins: true\` on develop has no exception.

This PR fixes both.

## Changes

- \`.github/commons-settings.yml\`: in the \`develop\` protection block,
  replace the hardcoded \`contexts: ["static / Static CI Tests"]\` with
  an empty array and add an inline comment that documents the
  consumer-side override pattern.
- Same block: add \`enforce_admins: true\` to bring the spec in line.

## Linked issues

None. Surfaced while running the \`project-structure-apply\` audit
against \`nolte/reachy-mini-mcp\`.

## Testing

YAML-only change in a Probot-consumed config. No unit tests exist for
this file in the repo. The settings app is the live consumer; once
this lands and a consumer repo's Probot install picks it up, the
result will be \`develop\` protected with no required contexts and
admin-enforced.

Verification on a downstream repo:

\`\`\`
gh api repos/<owner>/<repo>/branches/develop --jq '{protected, required_status_checks, enforce_admins}'
\`\`\`

should report \`protected: true\`, an empty contexts list, and
\`enforce_admins: true\`.

## Risk / rollout notes

- Settings-as-code change. No runtime behaviour modified.
- **Behaviour change for repos that depended on the old hardcoded
  context**: namely \`nolte/gh-plumbing\` itself. The \`static / Static
  CI Tests\` requirement on \`develop\` here will disappear when the
  Probot Settings App next syncs unless this repo declares the same
  context in its own \`.github/settings.yml\` (recommended follow-up
  PR).
- **Behaviour change for repos that already have the App synced**:
  \`enforce_admins\` flips to \`true\` on develop. This means admins can
  no longer bypass protection — flag in release notes if anyone in the
  org relied on the bypass.