### PR TITLE
fix(docker-publish): make latest-tag logic deterministic

### DIFF
--- a/.github/workflows/reusable-docker-publish.yaml
+++ b/.github/workflows/reusable-docker-publish.yaml
@@ -95,13 +95,27 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ inputs.registry }}/${{ github.repository_owner }}/${{ inputs.image_name }}
+          # Disable the action's default `latest=auto` so the `latest` tag is
+          # set exclusively by the explicit `type=raw,value=latest,enable=...`
+          # rule below. Without this, `latest=auto` adds a second, parallel
+          # source for the `latest` tag (every tag-ref dispatch resets it),
+          # which produced surprising drift in nolte/reachy-mini-mcp v0.1.1
+          # where a manual `workflow_dispatch --ref v0.1.1` rewrote `latest`.
+          flavor: |
+            latest=false
           tags: |
             type=ref,event=branch
             type=ref,event=pr
             type=sha,prefix=
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+            # `latest` is set on:
+            #   - a non-prerelease GitHub Release publish event, or
+            #   - a manual workflow_dispatch fired against a non-prerelease
+            #     semver tag ref (no `-` qualifier in the tag name).
+            # Both paths converge on the same intent: production releases
+            # always own `:latest`, prereleases and branch-refs never do.
+            type=raw,value=latest,enable=${{ (github.event_name == 'release' && !github.event.release.prerelease) || (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-')) }}
             ${{ inputs.tag_extra }}
 
       - name: Build and push


### PR DESCRIPTION
## Summary

The \`Extract metadata\` step in \`reusable-docker-publish.yaml\` had two
parallel sources writing the \`:latest\` tag. They happened to overlap
correctly on \`release: published\` events, but diverged on
\`workflow_dispatch --ref <tag>\`: the action's default
\`flavor: latest=auto\` silently set \`:latest\`, while the explicit
\`enable=...release\` rule didn't. \`nolte/reachy-mini-mcp\` v0.1.1
surfaced this — a manual tag-ref dispatch silently rewrote \`:latest\`
after the original release publish.

This PR disables the \`latest=auto\` default and extends the explicit
\`enable\` clause to cover both legitimate paths to \`:latest\`, so the
rule is single-sourced and deterministic.

## Changes

- \`.github/workflows/reusable-docker-publish.yaml\` \`Extract metadata\`
  step:
  - Add \`flavor: latest=false\` so docker/metadata-action no longer
    auto-applies \`:latest\` on semver tags.
  - Extend the \`type=raw,value=latest,enable=...\` rule to fire on:
    - a non-prerelease GitHub Release publish event (unchanged), **or**
    - a \`workflow_dispatch\` against a tag ref (\`refs/tags/...\`) whose
      name carries no \`-\` prerelease qualifier.
  - Inline-document both rules so future maintainers understand the
    intent.

## Linked issues

None. Behaviour surfaced while operating \`nolte/reachy-mini-mcp\`'s
release-cd-deliver-docker workflow against the same head SHA twice.

## Testing

Workflow-config-only change. Verification path on a downstream repo:

\`\`\`
gh workflow run release-cd-deliver-docker.yml --ref develop --repo <owner>/<repo>
# Expect: no :latest tag set on the resulting image index.

gh workflow run release-cd-deliver-docker.yml --ref v0.1.0 --repo <owner>/<repo>
# Expect: :latest is set, pointing at the v0.1.0 image index.

gh workflow run release-cd-deliver-docker.yml --ref v0.2.0-rc1 --repo <owner>/<repo>
# Expect: no :latest tag, :v0.2.0-rc1 and :sha tags only.
\`\`\`

## Risk / rollout notes

- **Behaviour change for branch-ref dispatches**: \`:latest\` is no
  longer set when dispatching against a branch ref (e.g.
  \`--ref develop\`). Previously the action's \`latest=auto\` silently
  set it. Downstream consumers who relied on this for branch-builds
  must dispatch against the tag ref instead.
- **Behaviour change for prerelease tags**: \`:latest\` is now reliably
  skipped for tag refs that contain \`-\` in the version qualifier.
  Previously some paths set it inconsistently.
- Consumers using \`@v1.1.16\` or older keep the previous behaviour.
  Consumers on \`@v1.1.17\` should bump to whatever release tag picks
  this PR up.