### PR TITLE
docs(probot): clarify _extends pinning contract and per-surface strategy

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -74,4 +74,6 @@
     ```
 
 !!! tip "Pinning strategy"
-    Reference `@develop` for the latest changes or pin to a release tag (for example `@v1.1.8`) for stability. The `master` branch refreshes automatically on every published release.
+    - **Reusable workflows:** `@develop` for latest, `@vX.Y.Z` for reproducibility, `@master` for the latest published release.
+    - **Probot `_extends`:** no pin possible—always resolves against `develop`. See [Probot → Settings → Versioning](probot/settings.md#versioning-drift-and-the-_extends-contract).
+    - **Renovate preset:** append `#vX.Y.Z` (note: `#`, not `@`) to pin to a release tag.

--- a/docs/probot/settings.md
+++ b/docs/probot/settings.md
@@ -37,3 +37,50 @@ repository:
    include "../../.github/commons-settings.yml"
 %}
 ```
+
+---
+
+## Versioning, drift, and the `_extends` contract
+
+!!! warning "`_extends @<ref>` isn't supported"
+    The Probot Settings App always resolves `_extends:` against the **default
+    branch** of the target repository. The parser rejects any `@<tag>`,
+    `@<sha>`, `?ref=…`, or `:vN` suffix on the `_extends:` value outright; it
+    doesn't strip the suffix and continue.
+    See [`octokit-plugin-config/src/util/extends-to-get-content-params.ts`][parser]
+    — the regex anchors at the start and excludes `@` from the filename token.
+
+    [parser]: https://github.com/probot/octokit-plugin-config/blob/main/src/util/extends-to-get-content-params.ts
+
+**Operational consequence.** Every consumer lives at the tip of
+`gh-plumbing/develop` for its Probot configuration. Whenever a
+`commons-*.yml` file changes here, every consumer drifts on its next sync
+trigger, with no signal back to the consumer. There is no reproducible
+snapshot: *"which `commons-settings.yml` state did this repository sync
+against last week?"* has no answer.
+
+**This is a known, accepted trade-off.** See issue
+[#337](https://github.com/nolte/gh-plumbing/issues/337) for the full
+investigation (parser source, alternatives matrix, decision rationale).
+
+### When this trade-off becomes blocking
+
+Three architectural alternatives are available the day drift turns load-bearing:
+
+| Approach | Mechanism | Pinning model |
+|---|---|---|
+| [`github/safe-settings`](https://github.com/github/safe-settings) | Central `admin` repository per org, three-level hierarchy (`org`/`suborg`/`repo`), PR-based dry-run CI | No pinning, but a single source per org eliminates cross-repository `_extends` resolves |
+| [`joshjohanning/bulk-github-repo-settings-sync-action`](https://github.com/marketplace/actions/bulk-github-repository-settings-sync) | GitHub Action invoked from a central repository on cron/push; inputs are file paths in the calling repository | Action version plus file content at a specific commit, giving a true snapshot |
+| Inline `commons-*.yml` into each consumer | Inline copy in each consumer's `.github/settings.yml` with a `# generated from gh-plumbing@<tag>` header; Renovate Custom Regex Manager bumps the header | Snapshot per consumer commit; full diff in the bump PR |
+
+Until then, treat **edits to `commons-*.yml` as a public API change** and
+roll them out as breaking changes.
+
+### Why the local `.github/settings.yml` here carries a propagation comment
+
+`gh-plumbing` is itself a consumer of its own commons. The Probot App reacts
+to push events that touch the **consumer's** `.github/settings.yml`, not the
+upstream `commons-*.yml`. To propagate a commons change, touch this
+repository's `.github/settings.yml` as well (a comment bump is enough). Issue
+[#331](https://github.com/nolte/gh-plumbing/issues/331) tracks this
+dog-fooding quirk.


### PR DESCRIPTION
## Summary

Document the Probot `_extends:` pinning contract — the parser rejects any
`@<tag>`, `@<sha>`, `?ref=…`, or `:vN` suffix outright (anchored regex in
`octokit-plugin-config`) — explain the resulting drift across consumers, and
list three architectural alternatives for the day that trade-off becomes
blocking. Split the landing-page pinning tip per surface so reusable
workflows, Probot `_extends`, and Renovate presets are no longer
misrepresented as uniformly `@vX.Y.Z`-pinnable.

## Changes

- Add new section *"Versioning, drift, and the `_extends` contract"* to
  `docs/probot/settings.md` covering the parser's hard rejection of suffixed
  `_extends:` values, the operational consequence (every consumer lives at
  the tip of `gh-plumbing/develop`), and three escape hatches:
  `github/safe-settings`, `joshjohanning/bulk-github-repo-settings-sync-action`,
  and inlining `commons-*.yml` into each consumer.
- Document the dog-fooding propagation quirk (consumer's
  `.github/settings.yml` must be touched for a commons change to roll out)
  and link it to issue #331.
- Split the landing-page *"Pinning strategy"* admonition in `docs/index.md`
  into three surface-specific lines: reusable workflows
  (`@develop` / `@vX.Y.Z` / `@master`), Probot `_extends` (no pin, deep-linked
  to the new section), and Renovate preset (`#vX.Y.Z`, note `#` vs `@`).

## Linked issues

Closes #337
Refs #331

## Testing

- `vale --minAlertLevel=error docs/index.md docs/probot/settings.md` → 0 errors, 0 warnings, 0 suggestions.
- `task lint` could not run locally (404 on the remote Taskfile include `taskfile-include-mkdocs.yaml` on the pinned `fix/py-var-names` branch); pre-commit fallback also unavailable for the active Python toolchain. Manual checks (trailing whitespace, trailing newline, Vale at error level) all pass; CI will run the full gate.
- MkDocs build verified by CI on the PR head.

## Risk / rollout notes

None. Documentation-only — no `commons-*.yml`, workflow, or Renovate-preset
change. Downstream consumers see no behaviour change.
