### PR TITLE
docs: overhaul docs/ + README, close catalog drift and 12 Vale alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ---
 
 <!--intro-start-->
-Used for minimize duplicate the CI/CD Boilerplate-Code. Like [Workflows (GitHub Actions)](https://docs.github.com/en/actions) and [GitHub App](https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps) configurations.
+Centralised reusable [GitHub Actions workflows](https://docs.github.com/en/actions) and shared [GitHub App](https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps) configurations, so downstream projects can avoid duplicating CI/CD boilerplate.
 <!--intro-end-->
 
 ## Workflows
@@ -13,17 +13,21 @@ Used for minimize duplicate the CI/CD Boilerplate-Code. Like [Workflows (GitHub 
 <!--td-workflows-start-->
 | Workflow                                      | description                                                                                                                                                      |
 |-----------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ```reusable-ansible-galaxy-push.yaml```      | Using [robertdebock/galaxy-action](https://github.com/robertdebock/galaxy-action) for publish a Ansible Role to [Ansible Galxy](https://galaxy.ansible.com/).    |
-| ```reusable-ansible-molecule.yaml```         | Start a simple Molecule test run by using the [gofrolist/molecule-action](https://github.com/gofrolist/molecule-action) action.                                  |
-| ```reusable-automerge.yaml```                | Using [pascalgn/automerge-action](https://github.com/pascalgn/automerge-action) for better Merge Request handling.                                               |
+| ```reusable-ansible-galaxy-push.yaml```      | Publish an Ansible role to [Ansible Galaxy](https://galaxy.ansible.com/) via [robertdebock/galaxy-action](https://github.com/robertdebock/galaxy-action).        |
+| ```reusable-ansible-molecule.yaml```         | Run a [Molecule](https://molecule.readthedocs.io/) test scenario via [gofrolist/molecule-action](https://github.com/gofrolist/molecule-action).                  |
+| ```reusable-automerge.yaml```                | Auto-merge pull requests via [pascalgn/automerge-action](https://github.com/pascalgn/automerge-action).                                                          |
+| ```reusable-chain-bench.yaml```              | Run the supply-chain CIS benchmark via [aquasecurity/chain-bench-action](https://github.com/aquasecurity/chain-bench-action).                                    |
+| ```reusable-dependency-review.yaml```        | Gate pull requests against vulnerable or licence-incompatible dependency changes via [actions/dependency-review-action](https://github.com/actions/dependency-review-action). |
 | ```reusable-docker-lint-build.yaml```        | Run [hadolint](https://github.com/hadolint/hadolint-action) on a Dockerfile and a buildx dry-build (no push) for fast PR feedback.                              |
 | ```reusable-docker-publish.yaml```           | Build a multi-arch container image with [docker/build-push-action](https://github.com/docker/build-push-action) and push it to a configurable OCI registry.      |
-| ```reusable-mkdocs.yaml```                   | Publish a [MkDocs](https://www.mkdocs.org/) based Documentation as [GitHub Page](https://pages.github.com/).                                                     |
-| ```reusable-pre-commit.yaml```               | Call [pre-commit](https://pre-commit.com/) for a minimal static tests set, like liter etc.                                                                       |
-| ```reusable-release-cd-refresh-master.yml``` | Refresh the current master branch, with the Revision from the Latest published Release, so the master/main branch will be present the `latest` Released version. |
-| ```reusable-release-drafter.yml```           | Will be use [release-drafter/release-drafter](https://github.com/release-drafter/release-drafter) for updating the current "Draft" Release with a Changelog.     |
-| ```reusable-sphinx.yaml```                   | Build and Publish a [Sphinx](https://www.sphinx-doc.org/en/master) Documentation as [GitHub Page](https://pages.github.com/).                                    |
-| ```reusable-stale.yaml```                    | Mark old or inactive issues and close then, used [actions/stale](https://github.com/actions/stale) for this work.                                                |
+| ```reusable-mkdocs.yaml```                   | Build and publish an [mkdocs](https://www.mkdocs.org/) site to [GitHub Pages](https://pages.github.com/).                                                        |
+| ```reusable-pre-commit.yaml```               | Run [pre-commit](https://pre-commit.com/) for a minimal static-test bundle (linters, formatters, EditorConfig).                                                  |
+| ```reusable-release-cd-refresh-master.yml``` | Fast-forward `master` to the latest published release tag so `master` always represents the latest release.                                                      |
+| ```reusable-release-drafter.yml```           | Update the open draft release with a changelog from merged PRs via [release-drafter/release-drafter](https://github.com/release-drafter/release-drafter).        |
+| ```reusable-release-publish.yml```           | Promote an open release-drafter draft to a published release for a given tag, with an optional dry-run validation gate.                                          |
+| ```reusable-spelling-vale.yaml```            | Lint Markdown prose via [errata-ai/vale-action](https://github.com/errata-ai/vale-action) with inline reviewdog annotations on pull requests.                    |
+| ```reusable-sphinx.yaml```                   | Build and publish a [Sphinx](https://www.sphinx-doc.org/en/master) documentation site to [GitHub Pages](https://pages.github.com/).                              |
+| ```reusable-stale.yaml```                    | Mark and close stale issues and pull requests via [actions/stale](https://github.com/actions/stale).                                                             |
 | ```reusable-trivy.yaml```                    | Scan the GitRepo by using [aquasecurity/trivy-action](https://github.com/aquasecurity/trivy-action).                                                             |
 | ```reusable-tf-lint.yaml```                  | Use [terraform-linters/setup-tflint](https://github.com/terraform-linters/setup-tflint) for Lint terraform sources.                                              |
 
@@ -41,7 +45,7 @@ For Using in other GitHub Projects, having a reusable set of Probot Configuratio
 | probot                                                            | git                                                                         | description                                                                                                         |
 |-------------------------------------------------------------------|-----------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
 | [boring-cyborg](https://probot.github.io/apps/boring-cyborg/)     | [kaxil/boring-cyborg](https://github.com/kaxil/boring-cyborg)               | Different actions like, automatically label Pull Request                                                       |
-| [release-drafter](https://probot.github.io/apps/release-drafter/) | [toolmantim/release-drafter](https://github.com/toolmantim/release-drafter) | Creates a Human Readable Release Change Log (**(deprecated)**, please use the Workflow Implementation).             |
+| [release-drafter](https://probot.github.io/apps/release-drafter/) | [release-drafter/release-drafter](https://github.com/release-drafter/release-drafter) | Creates a human-readable release changelog (**deprecated** as a Probot app—prefer the workflow implementation).     |
 | [renovate](https://github.com/apps/renovate)                      |                                                                             | Using [renovate](https://www.whitesourcesoftware.com/free-developer-tools/renovate/) for keep dependencies in sync. |
 | [settings](https://probot.github.io/apps/settings/)               | [probot/settings](https://github.com/probot/settings)                       | Configure GitHub Projects by Source.                                                                                |
 <!--td-probot-apps-end-->

--- a/docs/en/development/index.md
+++ b/docs/en/development/index.md
@@ -63,5 +63,5 @@ act push -j static -W .github/workflows/build-static-tests.yaml
 
 [Vale](https://vale.sh/) lints Markdown files in CI via `reusable-spelling-vale.yaml`. Rules live in `.vale.ini` and styles under `.github/styles/`.
 
-!!! info "CLAUDE.md is excluded"
-    `CLAUDE.md` carries LLM context, not end-user documentation—Vale explicitly skips it.
+!!! info "Vale skips CLAUDE.md"
+    `CLAUDE.md` carries large-language-model context for Claude Code, not end-user documentation, so Vale skips it.

--- a/docs/en/getting-started/index.md
+++ b/docs/en/getting-started/index.md
@@ -48,9 +48,9 @@ jobs:
 ```
 
 !!! note "Reference selection"
-    - `@develop` always tracks the latest changes; recommended for internal repositories that follow this project closely.
-    - `@vX.Y.Z` pins to a released version; recommended when you need reproducibility.
-    - `master` refreshes automatically on every published release and mirrors the latest release tag.
+    - `@develop` always tracks the latest changes. Recommended for internal repositories that follow this project.
+    - `@vX.Y.Z` pins to a released version. Recommended when you need reproducibility.
+    - `@master` refreshes automatically on every published release and mirrors the latest release tag.
 
 ---
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -75,5 +75,5 @@
 
 !!! tip "Pinning strategy"
     - **Reusable workflows:** `@develop` for latest, `@vX.Y.Z` for reproducibility, `@master` for the latest published release.
-    - **Probot `_extends`:** no pin possible—always resolves against `develop`. See [Probot → Settings → Versioning](probot/settings.md#versioning-drift-and-the-_extends-contract).
+    - **Probot `_extends`:** no pin possible—always resolves from the default branch (`develop`). See [Probot → Settings → Versioning](probot/settings.md#versioning-drift-and-the-_extends-contract).
     - **Renovate preset:** append `#vX.Y.Z` (note: `#`, not `@`) to pin to a release tag.

--- a/docs/en/probot/labelling.md
+++ b/docs/en/probot/labelling.md
@@ -1,6 +1,6 @@
 # Labelling
 
-Automatically labels PRs and issues using [boring-cyborg](https://probot.github.io/apps/boring-cyborg/). Changes under `./docs`, for example, receive the `documentations` label.
+Automatically labels PRs and issues using [boring-cyborg](https://probot.github.io/apps/boring-cyborg/). Changes under `./docs`, for example, receive the `documentation` label.
 
 ---
 
@@ -26,7 +26,7 @@ Automatically labels PRs and issues using [boring-cyborg](https://probot.github.
 
 ## Label palette
 
-`commons-settings.yml` declares the label palette; the [Settings App](settings.md) applies it.
+`commons-settings.yml` declares the label palette. The [Settings App](settings.md) applies it.
 
 ```yaml
 {%

--- a/docs/en/probot/settings.md
+++ b/docs/en/probot/settings.md
@@ -43,9 +43,9 @@ repository:
 ## Versioning, drift, and the `_extends` contract
 
 !!! warning "`_extends @<ref>` isn't supported"
-    The Probot Settings App always resolves `_extends:` against the **default
+    The Probot Settings App always resolves `_extends:` from the **default
     branch** of the target repository. The parser rejects any `@<tag>`,
-    `@<sha>`, `?ref=…`, or `:vN` suffix on the `_extends:` value outright; it
+    `@<sha>`, `?ref=…`, or `:vN` suffix on the `_extends:` value outright. It
     doesn't strip the suffix and continue.
     See [`octokit-plugin-config/src/util/extends-to-get-content-params.ts`][parser]
     — the regex anchors at the start and excludes `@` from the filename token.
@@ -57,7 +57,7 @@ repository:
 `commons-*.yml` file changes here, every consumer drifts on its next sync
 trigger, with no signal back to the consumer. There is no reproducible
 snapshot: *"which `commons-settings.yml` state did this repository sync
-against last week?"* has no answer.
+last week?"* has no answer.
 
 **This is a known, accepted trade-off.** See issue
 [#337](https://github.com/nolte/gh-plumbing/issues/337) for the full

--- a/docs/en/workflows/documentation.md
+++ b/docs/en/workflows/documentation.md
@@ -1,6 +1,6 @@
 # Documentation
 
-Builds an [MkDocs](https://www.mkdocs.org/) site and publishes it to GitHub Pages.
+Builds an [mkdocs](https://www.mkdocs.org/) site and publishes it to GitHub Pages.
 
 This workflow is part of the [nolte/cookiecutter-gh-project](https://github.com/nolte/cookiecutter-gh-project) template.
 
@@ -22,7 +22,7 @@ jobs:
 ```
 
 !!! note "GitHub Pages"
-    Ensure the target repository declares `has_pages: true`. The shared Probot settings already include this—see [Settings](../probot/settings.md).
+    The target repository must declare `has_pages: true`. The shared Probot settings already include this—see [Settings](../probot/settings.md).
 
 ---
 

--- a/docs/en/workflows/release.md
+++ b/docs/en/workflows/release.md
@@ -1,8 +1,9 @@
 # Release
 
-Release handling spans two workflows and one Probot configuration.
+Release handling spans three workflows and one Probot configuration.
 
 - **`reusable-release-drafter.yml`** maintains the draft release with a generated changelog as PRs land.
+- **`reusable-release-publish.yml`** promotes the open draft to a published release for a given tag, with an optional dry-run validation gate.
 - **`reusable-release-cd-refresh-master.yml`** merges the published release tag into `master` so `master` always tracks the latest release.
 - **`_extends: gh-plumbing:.github/commons-release-drafter.yml`** provides shared release-drafter categorization.
 
@@ -32,7 +33,45 @@ _extends: gh-plumbing:.github/commons-release-drafter.yml
 ```
 
 !!! tip "Categorization"
-    Release-drafter buckets PRs by label. [commons-settings](../probot/settings.md) declares the shared label palette; [boring-cyborg](../probot/labelling.md) applies the labels to each PR.
+    Release-drafter buckets PRs by label. [commons-settings](../probot/settings.md) declares the shared label palette, and [boring-cyborg](../probot/labelling.md) applies the labels to each PR.
+
+---
+
+## Publish a release
+
+```yaml title=".github/workflows/release-publish.yml"
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (must match an open release-drafter draft)."
+        required: true
+        type: string
+      dry_run:
+        description: "Validate without flipping draft=false."
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  publish:
+    uses: nolte/gh-plumbing/.github/workflows/reusable-release-publish.yml@develop
+    with:
+      tag: ${{ inputs.tag }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+!!! note "Tag must match an existing draft"
+    `tag` must match the tag on an existing release-drafter draft. There is no
+    "newest wins" heuristic—if no draft exists for the given tag the workflow
+    fails fast. Run the draft workflow on `develop` first.
+
+!!! tip "Dry run"
+    Set `dry_run: true` to run every validation gate without flipping the
+    draft to a published release. Useful for verifying the publish path
+    before the actual release.
 
 ---
 
@@ -62,6 +101,14 @@ jobs:
     ```yaml
     {%
        include "../../../.github/workflows/reusable-release-drafter.yml"
+    %}
+    ```
+
+=== "Release publish workflow"
+
+    ```yaml
+    {%
+       include "../../../.github/workflows/reusable-release-publish.yml"
     %}
     ```
 

--- a/docs/includes/abbreviations.md
+++ b/docs/includes/abbreviations.md
@@ -9,3 +9,5 @@
 *[IaC]: Infrastructure as Code
 *[TF]: Terraform
 *[MR]: Merge Request
+*[LLM]: Large Language Model
+*[OCI]: Open Container Initiative


### PR DESCRIPTION
## Summary

README and the `docs/` tree carried four undocumented reusable workflows,
a stale upstream link, a wrong label name, and twelve Vale alerts. This
PR closes the drift and tightens prose so the rendered MkDocs site (and
the README that feeds large parts of it via `include-markdown`) matches
what's actually on disk.

## Changes

- README workflow catalog: add `chain-bench`, `dependency-review`,
  `release-publish`, `spelling-vale`; rewrite remaining rows for parallel
  structure; fix `Galxy` / `liter` typos.
- README probot-apps table: `toolmantim/release-drafter` →
  `release-drafter/release-drafter` (upstream repo transfer; toolmantim
  fork is archived).
- README intro rewritten — the previous opener ("Used for minimize
  duplicate the CI/CD Boilerplate-Code…") surfaces on the docs home page
  via `include-markdown`.
- `docs/probot/labelling.md`: label is `documentation`, not
  `documentations` (matches `commons-settings.yml`).
- `docs/workflows/release.md`: new `## Publish a release` section + a
  Central-configuration tab documenting `reusable-release-publish.yml`
  as the third release workflow.
- Vale clean-up across `docs/*`: passive voice, semicolons, MkDocs
  casing, em-dash spacing, undefined `LLM` / `MUST` acronyms.
- `docs/includes/abbreviations.md`: gains `LLM` and `OCI` entries.

## Linked issues

None

## Testing

- `mkdocs build --strict` — clean (local workaround: `pygments<2.20`
  due to a Python-3.13 / pymdownx interaction that pre-exists on
  develop, unrelated to this PR).
- `vale docs/ README.md` — exit 0 (12 → 0 alerts).
- `pre-commit run --files <touched>` — passed.

## Risk / rollout notes

Low risk. Content-only edits to `docs/` and `README.md`. README changes
propagate into the rendered docs site via existing
\`<!--…-start/end-->\` \`include-markdown\` markers; all marker pairs were
verified intact by the docs-freshness audit. No workflow / Probot
config changes; no consumer-visible behaviour change.