### PR TITLE
docs(de): mirror #346 edits into docs/de/ tree

### DIFF
--- a/docs/de/development/index.md
+++ b/docs/de/development/index.md
@@ -63,5 +63,5 @@ act push -j static -W .github/workflows/build-static-tests.yaml
 
 [Vale](https://vale.sh/) prüft Markdown-Dateien im CI über `reusable-spelling-vale.yaml`. Die Regeln liegen in `.vale.ini`, die Styles unter `.github/styles/`.
 
-!!! info "CLAUDE.md ist ausgenommen"
-    `CLAUDE.md` trägt LLM-Kontext, keine Endnutzer-Dokumentation — Vale überspringt die Datei bewusst.
+!!! info "Vale überspringt CLAUDE.md"
+    `CLAUDE.md` trägt Large-Language-Model-Kontext für Claude Code, keine Endnutzer-Dokumentation, deshalb überspringt Vale die Datei.

--- a/docs/de/getting-started/index.md
+++ b/docs/de/getting-started/index.md
@@ -48,9 +48,9 @@ jobs:
 ```
 
 !!! note "Referenz-Auswahl"
-    - `@develop` folgt immer dem aktuellen Stand; empfohlen für interne Repositories, die dieses Projekt eng begleiten.
-    - `@vX.Y.Z` pinnt auf eine veröffentlichte Version; empfohlen, wenn Reproduzierbarkeit zählt.
-    - `master` aktualisiert sich automatisch bei jedem veröffentlichten Release und spiegelt den jeweils aktuellen Release-Tag.
+    - `@develop` folgt immer dem aktuellen Stand. Empfohlen für interne Repositories, die dieses Projekt begleiten.
+    - `@vX.Y.Z` pinnt auf eine veröffentlichte Version. Empfohlen, wenn Reproduzierbarkeit zählt.
+    - `@master` aktualisiert sich automatisch bei jedem veröffentlichten Release und spiegelt den jeweils aktuellen Release-Tag.
 
 ---
 

--- a/docs/de/index.md
+++ b/docs/de/index.md
@@ -75,5 +75,5 @@
 
 !!! tip "Pinning-Strategie"
     - **Wiederverwendbare Workflows:** `@develop` für den aktuellen Stand, `@vX.Y.Z` für Reproduzierbarkeit, `@master` für den jeweils zuletzt veröffentlichten Release.
-    - **Probot `_extends`:** kein Pin möglich — wird immer gegen `develop` aufgelöst. Siehe [Probot → Settings → Versionierung](probot/settings.md#versionierung-drift-und-der-_extends-kontrakt).
+    - **Probot `_extends`:** kein Pin möglich — wird immer vom Default-Branch (`develop`) aufgelöst. Siehe [Probot → Settings → Versionierung](probot/settings.md#versionierung-drift-und-der-_extends-kontrakt).
     - **Renovate-Preset:** mit `#vX.Y.Z` (Achtung: `#`, nicht `@`) an einen Release-Tag pinnen.

--- a/docs/de/probot/labelling.md
+++ b/docs/de/probot/labelling.md
@@ -1,6 +1,6 @@
 # Labelling
 
-Labelt PRs und Issues automatisch über [boring-cyborg](https://probot.github.io/apps/boring-cyborg/). Änderungen unter `./docs` erhalten zum Beispiel das Label `documentations`.
+Labelt PRs und Issues automatisch über [boring-cyborg](https://probot.github.io/apps/boring-cyborg/). Änderungen unter `./docs` erhalten zum Beispiel das Label `documentation`.
 
 ---
 
@@ -26,7 +26,7 @@ Labelt PRs und Issues automatisch über [boring-cyborg](https://probot.github.io
 
 ## Label-Palette
 
-`commons-settings.yml` deklariert die Label-Palette; die [Settings App](settings.md) wendet sie an.
+`commons-settings.yml` deklariert die Label-Palette. Die [Settings App](settings.md) wendet sie an.
 
 ```yaml
 {%

--- a/docs/de/probot/settings.md
+++ b/docs/de/probot/settings.md
@@ -43,9 +43,9 @@ repository:
 ## Versionierung, Drift und der `_extends`-Kontrakt
 
 !!! warning "`_extends @<ref>` wird nicht unterstützt"
-    Die Probot Settings App löst `_extends:` immer gegen den **Default-Branch**
+    Die Probot Settings App löst `_extends:` immer vom **Default-Branch**
     des Ziel-Repositories auf. Der Parser lehnt jeden Suffix `@<tag>`,
-    `@<sha>`, `?ref=…` oder `:vN` auf dem `_extends:`-Wert komplett ab; er
+    `@<sha>`, `?ref=…` oder `:vN` auf dem `_extends:`-Wert komplett ab. Er
     entfernt den Suffix nicht und fährt auch nicht fort.
     Siehe [`octokit-plugin-config/src/util/extends-to-get-content-params.ts`][parser]
     — der reguläre Ausdruck verankert am Anfang und schließt `@` aus dem Dateinamen-Token aus.
@@ -56,7 +56,7 @@ repository:
 am aktuellen Stand von `gh-plumbing/develop`. Sobald sich eine `commons-*.yml`
 hier ändert, driftet jeder Konsument beim nächsten Sync-Trigger — ohne Signal
 zurück an den Konsumenten. Es gibt keinen reproduzierbaren Snapshot: die Frage
-*„gegen welchen Stand von `commons-settings.yml` wurde dieses Repository letzte
+*„gegen welchen Stand von `commons-settings.yml` hat dieses Repository letzte
 Woche synchronisiert?"* hat keine Antwort.
 
 **Das ist ein bekannter, akzeptierter Trade-off.** Siehe Issue

--- a/docs/de/workflows/documentation.md
+++ b/docs/de/workflows/documentation.md
@@ -1,6 +1,6 @@
 # Dokumentation
 
-Baut eine [MkDocs](https://www.mkdocs.org/)-Site und veröffentlicht sie auf GitHub Pages.
+Baut eine [mkdocs](https://www.mkdocs.org/)-Site und veröffentlicht sie auf GitHub Pages.
 
 Dieser Workflow ist Teil des Templates [nolte/cookiecutter-gh-project](https://github.com/nolte/cookiecutter-gh-project).
 
@@ -22,7 +22,7 @@ jobs:
 ```
 
 !!! note "GitHub Pages"
-    Stelle sicher, dass das Ziel-Repository `has_pages: true` deklariert. Die geteilten Probot-Settings enthalten das bereits — siehe [Settings](../probot/settings.md).
+    Das Ziel-Repository muss `has_pages: true` deklarieren. Die geteilten Probot-Settings enthalten das bereits — siehe [Settings](../probot/settings.md).
 
 ---
 

--- a/docs/de/workflows/release.md
+++ b/docs/de/workflows/release.md
@@ -1,8 +1,9 @@
 # Release
 
-Das Release-Handling erstreckt sich über zwei Workflows und eine Probot-Konfiguration.
+Das Release-Handling erstreckt sich über drei Workflows und eine Probot-Konfiguration.
 
 - **`reusable-release-drafter.yml`** pflegt den Release-Entwurf mit generiertem Changelog, sobald Pull Requests gemerged werden.
+- **`reusable-release-publish.yml`** befördert den offenen Entwurf zu einem veröffentlichten Release für einen bestimmten Tag, mit optionalem Dry-Run-Validierungs-Gate.
 - **`reusable-release-cd-refresh-master.yml`** mergt den veröffentlichten Release-Tag in `master`, damit `master` immer dem aktuellen Release entspricht.
 - **`_extends: gh-plumbing:.github/commons-release-drafter.yml`** liefert die geteilte Release-Drafter-Kategorisierung.
 
@@ -32,7 +33,46 @@ _extends: gh-plumbing:.github/commons-release-drafter.yml
 ```
 
 !!! tip "Kategorisierung"
-    Release-Drafter sortiert PRs anhand von Labels. [commons-settings](../probot/settings.md) deklariert die geteilte Label-Palette; [boring-cyborg](../probot/labelling.md) hängt die Labels an die einzelnen PRs.
+    Release-Drafter sortiert PRs anhand von Labels. [commons-settings](../probot/settings.md) deklariert die geteilte Label-Palette, und [boring-cyborg](../probot/labelling.md) hängt die Labels an die einzelnen PRs.
+
+---
+
+## Release veröffentlichen
+
+```yaml title=".github/workflows/release-publish.yml"
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (must match an open release-drafter draft)."
+        required: true
+        type: string
+      dry_run:
+        description: "Validate without flipping draft=false."
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  publish:
+    uses: nolte/gh-plumbing/.github/workflows/reusable-release-publish.yml@develop
+    with:
+      tag: ${{ inputs.tag }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+!!! note "Tag muss zu einem bestehenden Entwurf passen"
+    `tag` muss zum Tag eines bestehenden Release-Drafter-Entwurfs passen. Es
+    gibt keine „neuester gewinnt"-Heuristik — existiert kein Entwurf für den
+    angegebenen Tag, scheitert der Workflow sofort. Lass vorher den
+    Draft-Workflow auf `develop` laufen.
+
+!!! tip "Dry Run"
+    Setze `dry_run: true`, um jeden Validierungs-Gate auszuführen, ohne den
+    Entwurf zu einem veröffentlichten Release umzuschalten. Nützlich, um den
+    Publish-Pfad vor dem eigentlichen Release zu verifizieren.
 
 ---
 
@@ -62,6 +102,14 @@ jobs:
     ```yaml
     {%
        include "../../../.github/workflows/reusable-release-drafter.yml"
+    %}
+    ```
+
+=== "Release-Publish-Workflow"
+
+    ```yaml
+    {%
+       include "../../../.github/workflows/reusable-release-publish.yml"
     %}
     ```
 


### PR DESCRIPTION
## Summary

Closes the German-translation drift opened by #346, which only touched
`docs/en/` because it was rebased on top of #347's i18n split. This PR
mirrors each EN edit into the matching DE page so both language trees
carry the same semantic content again.

## Changes

- `docs/de/workflows/release.md`: add the new "Release veröffentlichen"
  section plus the "Release-Publish-Workflow" central-config tab; update
  the intro from "zwei" to "drei Workflows"; rephrase the
  Categorization tip
- `docs/de/workflows/documentation.md`: MkDocs → mkdocs casing;
  "Stelle sicher" → "muss deklarieren"
- `docs/de/probot/settings.md`: `_extends` "gegen den" → "vom";
  semicolon → period in the parser-rejection sentence; tighten the
  rhetorical snapshot question
- `docs/de/probot/labelling.md`: typo fix `documentations` → `documentation`;
  semicolon → period before "Die Settings App"
- `docs/de/getting-started/index.md`: rewrite the three Referenz-Auswahl
  list items (period instead of semicolon, `master` → `@master`)
- `docs/de/index.md`: Pinning-tip wording about the default branch
- `docs/de/development/index.md`: rework the Vale admonition wording

YAML code blocks and identifiers stay English as required by the
CLAUDE.md user-language policy.

## Linked issues

Refs #346

## Testing

- `mkdocs build --strict` — both `en` and `de` trees build cleanly,
  no warnings
- `pre-commit run --all-files` — all hooks green
- Spot-check via diff: every EN edit landed under `docs/de/` has a
  semantic counterpart, no DE-only edits and no orphan EN edits

## Risk / rollout notes

Low. Content-only edits to `docs/de/`. EN tree untouched. Rendered URLs
under `/de/...` are unaffected (no page renames). Build-time dependency
set unchanged.