### PR TITLE
feat(terraform): add portfolio-app provisioning module (stacked on #349)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,16 @@ site
 !.github/styles/.keep
 .task
 .claude/
+
+# Terraform: ignore the local plugin cache and per-run plan files;
+# .terraform.lock.hcl is kept under version control on purpose.
+**/.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc

--- a/docs/de/portfolio-app/setup.md
+++ b/docs/de/portfolio-app/setup.md
@@ -74,6 +74,14 @@ Installation-Token holen.
      [Actions-Secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets)) —
      der vollständige PEM-Inhalt aus Schritt 3.
 
+!!! tip "Terraform-getriebene Provisionierung"
+    Die Schritte 5 und 6 sind auch als Terraform-Modul unter
+    [`terraform/portfolio-app/`](https://github.com/nolte/gh-plumbing/tree/develop/terraform/portfolio-app)
+    verfügbar. Das Modul legt die Org-Variable und das Org-Secret in
+    einem `terraform apply` an und deklariert optional die App als
+    Branch-Protection-Bypass-Actor. Schritte 1–4 bleiben manuell, weil
+    GitHub keine API zur App-Erstellung anbietet.
+
 ---
 
 ## Wrapper-Pattern (für nachgelagerte Konsumenten)

--- a/docs/en/portfolio-app/setup.md
+++ b/docs/en/portfolio-app/setup.md
@@ -71,6 +71,14 @@ token at job start use the App exclusively.
      [Actions secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets))
      holding the full private-key contents from step 3.
 
+!!! tip "Terraform-driven provisioning"
+    Steps 5 and 6 are also available as a Terraform module under
+    [`terraform/portfolio-app/`](https://github.com/nolte/gh-plumbing/tree/develop/terraform/portfolio-app).
+    The module creates the org-level variable and secret in one
+    `terraform apply` and (optionally) declares the App as a
+    branch-protection bypass actor. Steps 1–4 stay manual because
+    GitHub provides no API to create an App.
+
 ---
 
 ## Wrapper pattern (for downstream consumers)

--- a/terraform/portfolio-app/.terraform.lock.hcl
+++ b/terraform/portfolio-app/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "6.12.1"
+  constraints = "~> 6.6"
+  hashes = [
+    "h1:bGz4LIep/7PVrqy6P8cTYbAJpdxXGrupUJjkCczlzIs=",
+    "zh:3e1a4081ecb9518fdf0074db83c16ad00dc81ffe8249a6e3cf1894e947e28df6",
+    "zh:4cb8224b7f530795b674ac044675f6b22a7c9154f55eb9f76c5af6c7534056a4",
+    "zh:560bc08637926191f6871a89e986022ca67c70afda5bebca34b5216e6fac69c9",
+    "zh:5a70b5d2ac650c5c9819a1875411ebda229d0fcc6c9f57f9d751852ca3cd77ac",
+    "zh:8668d93bd4dc2ffa2545e1473af600a925d479b16033a71a4498a16f3b683c0c",
+    "zh:86eacc6059fd057948e178b665ba5cce74bd5488a9e1035734e60ff5ef1b6f8f",
+    "zh:a329fac98881d8dfc211a9bdc0ec6f2948f0b0c2704d1b6cbe5307403c7ad1b2",
+    "zh:dadd44abab3c52b9d572955afaef1658790e17ea355ee22b58996d81d28e02d8",
+    "zh:de9f455ef342cc38fb76bce844bfcd376fb81a4b9f9bc2fae023ff99efdf1338",
+    "zh:f8c6d2e8351b334491790358574e0a30a7c6d7f5b80f7daf32a7c0f3e9b1ab19",
+    "zh:fab41971a3edee04ab6eceaeab4eeb9a2b2f38a2af3b06eda93e2117b64994be",
+    "zh:fb1279b566dd9c8c117b2e4e0cc8344413b8fc8f2a3e24be22a9b2610551777b",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+    "zh:fe79d2a861fb9af420fa5bd7f02c031b2a0a3edf5dbc46022c8ecc7a33cf2b6d",
+  ]
+}

--- a/terraform/portfolio-app/README.md
+++ b/terraform/portfolio-app/README.md
@@ -1,0 +1,132 @@
+# Portfolio-app terraform module
+
+Provisions the **organisation-level Actions variable and secret** and
+(optionally) the **branch-protection bypass** that the
+[portfolio GitHub App](../../docs/en/portfolio-app/setup.md) needs to
+close the `GITHUB_TOKEN` cascade gap tracked in
+[issue #330](https://github.com/nolte/gh-plumbing/issues/330).
+
+The module is the Terraform-driven alternative to the manual
+GitHub-UI checklist in `docs/en/portfolio-app/setup.md`. It replaces
+three manual steps (set organisation variable, set organisation
+secret, repeat per repository) with one `terraform apply`.
+
+## What it provisions
+
+| Resource | Scope | Purpose |
+|---|---|---|
+| `github_actions_organization_variable.portfolio_app_id` | organisation-wide, `visibility = "selected"` | Holds the App ID under the name `PORTFOLIO_APP_ID`. Wrappers read it from `vars.PORTFOLIO_APP_ID`. |
+| `github_actions_organization_secret.portfolio_app_private_key` | organisation-wide, `visibility = "selected"` | Holds the private key under the name `PORTFOLIO_APP_PRIVATE_KEY`. Wrappers read it from `secrets.PORTFOLIO_APP_PRIVATE_KEY`. |
+| `github_branch_protection.bypass` (optional) | per repository per branch | Declares the App as a push-restriction (bypass) actor on the protected branches. Enables the workflow-driven primary path of `spec/project/release-automation/` §Version-bearing file alignment. |
+
+## What it doesn't provision
+
+- **The GitHub App itself.** GitHub exposes no public API to *create*
+  an App. The App ID and private key come from the registration flow
+  at `https://github.com/settings/apps/new`. Register the App
+  manually first, then feed the resulting App ID, slug, and private
+  key into this module.
+- **The App's per-repository installation.** Installing an App into a
+  repository is a UI or account-owner action that the Terraform
+  GitHub provider doesn't expose consistently. The module assumes the
+  App already lives in every repository listed in
+  `consumer_repositories`. The Terraform module covers everything
+  downstream of the App being live; it doesn't replace the one-time
+  install click.
+
+## Pre-conditions
+
+Before `terraform apply`:
+
+1. The portfolio App carries the permissions listed in
+   `docs/en/portfolio-app/setup.md` §Permissions the app requires.
+2. The App lives in every repository you intend to list under
+   `consumer_repositories`.
+3. The Terraform provider holds credentials for `var.organization`
+   with sufficient permissions:
+   - `admin:org` (organisation-secret and organisation-variable management).
+   - `repo` (branch protection, only needed when
+     `enable_branch_bypass = true`).
+   - `read:org` (data lookup over the organisation's repository list).
+4. The App ID, App slug, and App private key live locally (typically
+   loaded from an external secret manager, not committed).
+
+## Inputs
+
+| Name | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `organization` | string | yes | — | GitHub organisation (or user) that owns the consumer repositories. |
+| `app_id` | string | yes | — | Numeric App ID. |
+| `app_private_key` | string (sensitive) | yes | — | Private key in Privacy-Enhanced-Mail format. |
+| `app_slug` | string | yes | — | App slug (the path segment after `/apps/` in the App's web address). |
+| `consumer_repositories` | list(string) | yes | — | Repositories that should see the variable and secret (and the bypass entry when enabled). |
+| `enable_branch_bypass` | `bool` | no | `false` | Phase 2 toggle. Flip to `true` only after the App lives in every consumer repository and after a cross-repository security review. |
+| `protected_branches` | list(string) | no | `["develop", "master"]` | Branches that receive the bypass entry when Phase 2 is on. |
+
+## Outputs
+
+| Name | Description |
+|---|---|
+| `configured_repositories` | Repository names now seeing the organisation-level variable and secret. |
+| `variable_name` | `PORTFOLIO_APP_ID` (informational, mirrors the wrapper contract). |
+| `secret_name` | `PORTFOLIO_APP_PRIVATE_KEY` (informational, mirrors the wrapper contract). |
+| `branch_bypass_enabled` | Mirrors the input flag. |
+| `branch_bypass_pairs` | `repo::branch` pairs that received the bypass entry. Empty when Phase 2 is off. |
+
+## Usage
+
+See [`examples/basic/`](./examples/basic/) for a runnable end-to-end
+example. The shortest possible adoption:
+
+```hcl
+module "portfolio_app" {
+  source = "github.com/nolte/gh-plumbing//terraform/portfolio-app?ref=develop"
+
+  organization = "nolte"
+  app_id       = var.portfolio_app_id
+  app_slug     = "nolte-portfolio-bot"
+
+  # Loaded from your secret manager (environment variable, vault, sops, …).
+  app_private_key = var.portfolio_app_private_key
+
+  consumer_repositories = [
+    "gh-plumbing",
+    "claude-shared",
+    # add further consumers as they adopt the wrapper pattern
+  ]
+
+  # Default off. Flip once the App lives in every listed repository
+  # and the consumer wrappers carry the new pattern.
+  enable_branch_bypass = false
+}
+```
+
+## Phase roll-out
+
+The module supports the three-phase migration described in
+`docs/en/portfolio-app/setup.md`:
+
+| Phase | Module input | Result |
+|---|---|---|
+| Phase 0 | `enable_branch_bypass = false`, partial `consumer_repositories` | Organisation variable and secret created, visible only to the listed repositories. Wrappers in those repositories can adopt the App-token path. |
+| Phase 2 | `enable_branch_bypass = true`, same `consumer_repositories` | Branch protection updated to let the App through. Workflow-driven primary path of `release-automation` becomes available. |
+| Phase 3 | extend `consumer_repositories` as new repositories adopt the wrappers | Variable and secret automatically extend to the new repositories. |
+
+## Versioning
+
+The module follows the gh-plumbing release cadence. Pin it like any
+other reusable artefact:
+
+```hcl
+source = "github.com/nolte/gh-plumbing//terraform/portfolio-app?ref=v1.x.y"
+```
+
+Use `?ref=develop` only for portfolio repositories that intentionally
+track the latest plumbing changes.
+
+## Related
+
+- Issue: [#330](https://github.com/nolte/gh-plumbing/issues/330)
+- PR introducing the wrapper pattern in `nolte/gh-plumbing`
+- Documentation: [`docs/en/portfolio-app/setup.md`](../../docs/en/portfolio-app/setup.md) and
+  [`docs/de/portfolio-app/setup.md`](../../docs/de/portfolio-app/setup.md)

--- a/terraform/portfolio-app/examples/basic/README.md
+++ b/terraform/portfolio-app/examples/basic/README.md
@@ -1,0 +1,40 @@
+# Basic example: Portfolio-app module
+
+End-to-end runnable example for a single consumer repository
+(`nolte/gh-plumbing` dog-fooding itself).
+
+## Pre-conditions
+
+- The portfolio GitHub App lives in `nolte/gh-plumbing`.
+- The `GITHUB_TOKEN` environment variable holds a token with
+  `admin:org`, `repo`, and `read:org` scopes for the `nolte`
+  organisation.
+- `TF_VAR_portfolio_app_id` and `TF_VAR_portfolio_app_private_key`
+  carry values from your local secret manager (not committed).
+
+## Run
+
+```sh
+export GITHUB_TOKEN=ghp_...
+export TF_VAR_portfolio_app_id=1234567
+export TF_VAR_portfolio_app_private_key="$(cat ~/secrets/portfolio-app.pem)"
+
+terraform init
+terraform plan -out plan.tfplan
+terraform apply plan.tfplan
+```
+
+## Expected result
+
+- Organisation-level Actions variable `PORTFOLIO_APP_ID` visible to
+  `nolte/gh-plumbing`.
+- Organisation-level Actions secret `PORTFOLIO_APP_PRIVATE_KEY`
+  visible to `nolte/gh-plumbing`.
+- No branch-protection change (`enable_branch_bypass = false`).
+
+## Phase 2 follow-up
+
+Once every repository in `consumer_repositories` runs the updated
+wrapper pattern, flip `enable_branch_bypass` to `true` and re-apply.
+Terraform plan output then shows added `github_branch_protection.bypass`
+resources only.

--- a/terraform/portfolio-app/examples/basic/main.tf
+++ b/terraform/portfolio-app/examples/basic/main.tf
@@ -1,0 +1,50 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.6"
+    }
+  }
+}
+
+# Authenticate against the org you administer. The token needs
+# admin:org, repo, and read:org per the module README.
+provider "github" {
+  owner = "nolte"
+  # token = read from GITHUB_TOKEN env var by default
+}
+
+# Load the App private key from somewhere that is NOT version control.
+# This example uses an environment variable; swap for sops/vault/etc.
+variable "portfolio_app_id" {
+  type = string
+}
+
+variable "portfolio_app_private_key" {
+  type      = string
+  sensitive = true
+}
+
+module "portfolio_app" {
+  source = "../.."
+
+  organization    = "nolte"
+  app_id          = var.portfolio_app_id
+  app_slug        = "nolte-portfolio-bot"
+  app_private_key = var.portfolio_app_private_key
+
+  consumer_repositories = [
+    "gh-plumbing",
+  ]
+
+  # Phase 0: leave bypass off until every consumer in the list above
+  # has the App installed AND its wrappers updated. Flip to true in a
+  # follow-up apply once both are confirmed.
+  enable_branch_bypass = false
+}
+
+output "configured" {
+  value = module.portfolio_app.configured_repositories
+}

--- a/terraform/portfolio-app/main.tf
+++ b/terraform/portfolio-app/main.tf
@@ -1,0 +1,65 @@
+# Org-level Actions variable holding the App ID.
+#
+# The wrapper workflows in nolte/gh-plumbing read vars.PORTFOLIO_APP_ID
+# inside their `if:` condition. Storing the ID as a variable (not a
+# secret) is intentional — the ID is non-sensitive and the GitHub Actions
+# `secrets` context cannot be read reliably from job-level `if:` blocks.
+resource "github_actions_organization_variable" "portfolio_app_id" {
+  variable_name = "PORTFOLIO_APP_ID"
+  visibility    = "selected"
+  value         = var.app_id
+  selected_repository_ids = [
+    for r in data.github_repository.consumers : r.repo_id
+  ]
+}
+
+# Org-level Actions secret holding the App's PEM private key.
+#
+# Combined with PORTFOLIO_APP_ID above, this lets each consumer's
+# wrapper mint a short-lived App installation token via
+# actions/create-github-app-token@v2.
+resource "github_actions_organization_secret" "portfolio_app_private_key" {
+  secret_name     = "PORTFOLIO_APP_PRIVATE_KEY"
+  visibility      = "selected"
+  plaintext_value = var.app_private_key
+  selected_repository_ids = [
+    for r in data.github_repository.consumers : r.repo_id
+  ]
+}
+
+# Data lookup for each consumer repository — needed to translate names
+# into the numeric repo IDs both organisation-secret/-variable
+# resources require.
+data "github_repository" "consumers" {
+  for_each  = toset(var.consumer_repositories)
+  full_name = "${var.organization}/${each.value}"
+}
+
+# Phase 2 (opt-in): declare the App as a push-restriction (bypass)
+# actor on each protected branch of each consumer repository. This
+# enables the workflow-driven primary path of
+# spec/project/release-automation/ §Version-bearing file alignment.
+#
+# Caveat: this only works for branches that have a protection rule. The
+# resource will create one if missing; consumers that manage branch
+# protection through Probot Settings App + .github/settings.yml should
+# review whether Terraform should own the rule or just augment it (the
+# integrations/github provider does not patch existing rules — it
+# replaces them on the keys it manages).
+resource "github_branch_protection" "bypass" {
+  for_each = var.enable_branch_bypass ? {
+    for pair in setproduct(var.consumer_repositories, var.protected_branches) :
+    "${pair[0]}::${pair[1]}" => {
+      repository = pair[0]
+      branch     = pair[1]
+    }
+  } : {}
+
+  repository_id  = data.github_repository.consumers[each.value.repository].node_id
+  pattern        = each.value.branch
+  enforce_admins = true
+
+  restrict_pushes {
+    push_allowances = ["/${var.app_slug}"]
+  }
+}

--- a/terraform/portfolio-app/outputs.tf
+++ b/terraform/portfolio-app/outputs.tf
@@ -1,0 +1,24 @@
+output "configured_repositories" {
+  description = "Repository names that now see the portfolio App's variable and secret. Match against var.consumer_repositories to confirm."
+  value       = [for r in data.github_repository.consumers : r.name]
+}
+
+output "variable_name" {
+  description = "Name of the org-level Actions variable consumers reference (PORTFOLIO_APP_ID). Exposed for symmetry with the wrapper docs."
+  value       = github_actions_organization_variable.portfolio_app_id.variable_name
+}
+
+output "secret_name" {
+  description = "Name of the org-level Actions secret consumers reference (PORTFOLIO_APP_PRIVATE_KEY). Exposed for symmetry with the wrapper docs."
+  value       = github_actions_organization_secret.portfolio_app_private_key.secret_name
+}
+
+output "branch_bypass_enabled" {
+  description = "True when var.enable_branch_bypass was set; informational, mirrors the input."
+  value       = var.enable_branch_bypass
+}
+
+output "branch_bypass_pairs" {
+  description = "Repository::branch pairs that received the App as a push-restriction actor. Empty when enable_branch_bypass is false."
+  value       = keys(github_branch_protection.bypass)
+}

--- a/terraform/portfolio-app/variables.tf
+++ b/terraform/portfolio-app/variables.tf
@@ -1,0 +1,57 @@
+variable "organization" {
+  description = "GitHub organisation (or user) that owns the consumer repositories. The provider must be authenticated against this scope."
+  type        = string
+}
+
+variable "app_id" {
+  description = "Numeric ID of the portfolio GitHub App (visible on its settings page). Written to the org-level Actions variable PORTFOLIO_APP_ID."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9]+$", var.app_id))
+    error_message = "app_id must be the numeric App ID (digits only)."
+  }
+}
+
+variable "app_private_key" {
+  description = "PEM-encoded private key for the portfolio GitHub App. Written to the org-level Actions secret PORTFOLIO_APP_PRIVATE_KEY. Marked sensitive."
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = can(regex("BEGIN (RSA )?PRIVATE KEY", var.app_private_key))
+    error_message = "app_private_key must contain a PEM header (e.g. -----BEGIN RSA PRIVATE KEY-----)."
+  }
+}
+
+variable "app_slug" {
+  description = "Slug of the portfolio GitHub App (the part of the App URL after /apps/, e.g. 'nolte-portfolio-bot'). Used to declare the App as a branch-protection bypass actor when enable_branch_bypass is true."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]+$", var.app_slug))
+    error_message = "app_slug must be lowercase letters, digits, and hyphens only."
+  }
+}
+
+variable "consumer_repositories" {
+  description = "Names of repositories in var.organization that should consume the portfolio App. The module sets visibility=selected on the org-level variable + secret to this list, and (when enable_branch_bypass is true) configures branch protection with the App as a bypass actor."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.consumer_repositories) > 0
+    error_message = "consumer_repositories must list at least one repository name."
+  }
+}
+
+variable "enable_branch_bypass" {
+  description = "When true, configure branch protection on var.protected_branches for every consumer repository with var.app_slug declared as a push-restriction (bypass) actor. This is Phase 2 of issue #330. Default off so Phase 0 (credentials + selection) can land independently."
+  type        = bool
+  default     = false
+}
+
+variable "protected_branches" {
+  description = "Branches per consumer repository that receive the bypass entry when enable_branch_bypass is true. Order does not matter."
+  type        = list(string)
+  default     = ["develop", "master"]
+}

--- a/terraform/portfolio-app/versions.tf
+++ b/terraform/portfolio-app/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.6"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Stacked on #349. Adds a Terraform module under `terraform/portfolio-app/`
that automates Phase 0 (org-level variable + secret with selected-repo
visibility) and Phase 2 (branch-protection bypass) of the workflow-
health remediation tracked in #330. Replaces three of the six steps in
the manual provisioning checklist with one `terraform apply`.

## Changes

- `terraform/portfolio-app/versions.tf` — pins `terraform >= 1.6` and
  `integrations/github ~> 6.6`.
- `terraform/portfolio-app/variables.tf` — typed inputs with
  client-side validation (numeric `app_id`, PEM `app_private_key`,
  slug pattern, non-empty `consumer_repositories`).
- `terraform/portfolio-app/main.tf` — `github_actions_organization_variable`
  + `_secret` with `visibility = "selected"`, scoped to the listed
  repos; optional `github_branch_protection.bypass` per repo × branch
  behind `enable_branch_bypass` flag.
- `terraform/portfolio-app/outputs.tf` — confirms configured repos and
  mirrors the variable/secret names from the wrapper contract.
- `terraform/portfolio-app/README.md` — pre-conditions, inputs /
  outputs, usage, three-phase mapping, versioning guidance.
- `terraform/portfolio-app/examples/basic/` — runnable single-consumer
  dog-fooding example for `nolte/gh-plumbing` itself.
- `docs/{en,de}/portfolio-app/setup.md` — tip box right after manual
  step 6 pointing at the module as the Terraform-driven alternative.
- `.gitignore` — adds Terraform plugin-cache and per-run plan-file
  entries; `.terraform.lock.hcl` is kept under version control on
  purpose.

## What this module does **not** do

- **Register the App.** There is no GitHub API to create an App; the
  App ID and private key come from the manual registration flow.
- **Install the App in repos.** App installation requires UI/account
  owner action and isn't consistently exposed by the GitHub provider.

The Terraform module covers everything downstream of those two manual
steps.

## Linked issues

Refs #330
Refs #349 (stacked on top of)

## Testing

- `terraform fmt -recursive` — clean.
- `terraform init -backend=false` — provider downloaded.
- `terraform validate` — `Success! The configuration is valid.`
- `mkdocs build --strict` — both `en` and `de` trees build cleanly.
- `pre-commit run --all-files` — all hooks green.

## Risk / rollout notes

Low — the module is opt-in. Consumers run `terraform apply` only after
registering the App manually. `enable_branch_bypass` defaults to
`false`, so a first `terraform apply` does only the variable + secret
work (no security-relevant change yet).

Provider authentication needs `admin:org` (org-secret + variable
management), `repo` (only when `enable_branch_bypass = true`), and
`read:org` (data lookup against the repo list). Document this in your
runbook before granting an automation token those scopes.

**Stacked-PR note:** This PR targets `feat/portfolio-app-token-wrappers`
(PR #349), not `develop`. Merging #349 first lets GitHub
auto-retarget this to `develop` once the stack base lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)