### PR TITLE
feat(terraform): add user-account mode to portfolio-app module

### DIFF
--- a/terraform/portfolio-app/README.md
+++ b/terraform/portfolio-app/README.md
@@ -11,12 +11,40 @@ GitHub-UI checklist in `docs/en/portfolio-app/setup.md`. It replaces
 three manual steps (set organisation variable, set organisation
 secret, repeat per repository) with one `terraform apply`.
 
+## Owner modes
+
+The module runs in one of two modes depending on which owner input
+you set. Pick the one that matches the GitHub account that owns the
+consumer repositories.
+
+| Mode | Set | Resources |
+|---|---|---|
+| Organisation mode | `organization = "<org>"` | one organisation-level variable and secret with `visibility = "selected"` scoped to `consumer_repositories` |
+| User mode | `user = "<handle>"` | one repository-level variable and secret per repository in `consumer_repositories` (organisation-level Actions resources don't exist for personal accounts) |
+
+Set **exactly one** input. The module fails fast at plan time when
+the configuration sets both or neither.
+
 ## What it provisions
+
+### Organisation mode
 
 | Resource | Scope | Purpose |
 |---|---|---|
 | `github_actions_organization_variable.portfolio_app_id` | organisation-wide, `visibility = "selected"` | Holds the App ID under the name `PORTFOLIO_APP_ID`. Wrappers read it from `vars.PORTFOLIO_APP_ID`. |
 | `github_actions_organization_secret.portfolio_app_private_key` | organisation-wide, `visibility = "selected"` | Holds the private key under the name `PORTFOLIO_APP_PRIVATE_KEY`. Wrappers read it from `secrets.PORTFOLIO_APP_PRIVATE_KEY`. |
+
+### User mode
+
+| Resource | Scope | Purpose |
+|---|---|---|
+| `github_actions_variable.portfolio_app_id` (per repository) | repository-level | Holds the App ID under the name `PORTFOLIO_APP_ID` on each consumer repository. |
+| `github_actions_secret.portfolio_app_private_key` (per repository) | repository-level | Holds the private key under the name `PORTFOLIO_APP_PRIVATE_KEY` on each consumer repository. |
+
+### Both modes
+
+| Resource | Scope | Purpose |
+|---|---|---|
 | `github_branch_protection.bypass` (optional) | per repository per branch | Declares the App as a push-restriction (bypass) actor on the protected branches. Enables the workflow-driven primary path of `spec/project/release-automation/` §Version-bearing file alignment. |
 
 ## What it doesn't provision
@@ -42,12 +70,14 @@ Before `terraform apply`:
    `docs/en/portfolio-app/setup.md` §Permissions the app requires.
 2. The App lives in every repository you intend to list under
    `consumer_repositories`.
-3. The Terraform provider holds credentials for `var.organization`
-   with sufficient permissions:
-   - `admin:org` (organisation-secret and organisation-variable management).
-   - `repo` (branch protection, only needed when
-     `enable_branch_bypass = true`).
-   - `read:org` (data lookup over the organisation's repository list).
+3. The Terraform provider holds credentials for the owner account
+   (`var.organization` or `var.user`) with sufficient permissions:
+   - **Organisation mode:** `admin:org` (organisation-secret and
+     organisation-variable management), `repo` (branch protection,
+     only needed when `enable_branch_bypass = true`), `read:org`
+     (data lookup over the organisation's repository list).
+   - **User mode:** `repo` (repository-level Actions variables,
+     secrets, and branch protection). No `admin:org` needed.
 4. The App ID, App slug, and App private key live locally (typically
    loaded from an external secret manager, not committed).
 
@@ -55,11 +85,12 @@ Before `terraform apply`:
 
 | Name | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `organization` | string | yes | — | GitHub organisation (or user) that owns the consumer repositories. |
-| `app_id` | string | yes | — | Numeric App ID. |
-| `app_private_key` | string (sensitive) | yes | — | Private key in Privacy-Enhanced-Mail format. |
-| `app_slug` | string | yes | — | App slug (the path segment after `/apps/` in the App's web address). |
-| `consumer_repositories` | list(string) | yes | — | Repositories that should see the variable and secret (and the bypass entry when enabled). |
+| `organization` | string | one of | `""` | GitHub organisation that owns the consumer repositories. Mutually exclusive with `user`. |
+| `user` | string | one of | `""` | GitHub user account that owns the consumer repositories. Mutually exclusive with `organization`. |
+| `app_id` | string | yes | n/a | Numeric App ID. |
+| `app_private_key` | string (sensitive) | yes | n/a | Private key in Privacy-Enhanced-Mail format. |
+| `app_slug` | string | yes | n/a | App slug (the path segment after `/apps/` in the App's web address). |
+| `consumer_repositories` | list(string) | yes | n/a | Repositories that should see the variable and secret (and the bypass entry when enabled). |
 | `enable_branch_bypass` | `bool` | no | `false` | Phase 2 toggle. Flip to `true` only after the App lives in every consumer repository and after a cross-repository security review. |
 | `protected_branches` | list(string) | no | `["develop", "master"]` | Branches that receive the bypass entry when Phase 2 is on. |
 
@@ -67,7 +98,9 @@ Before `terraform apply`:
 
 | Name | Description |
 |---|---|
-| `configured_repositories` | Repository names now seeing the organisation-level variable and secret. |
+| `mode` | Which owner mode the module ran in. Value is `organization` or `user`. |
+| `owner` | The owner string (organisation or user) the module resolved at plan time. |
+| `configured_repositories` | Repository names now seeing the variable and secret (organisation-scoped or repository-scoped, depending on mode). |
 | `variable_name` | `PORTFOLIO_APP_ID` (informational, mirrors the wrapper contract). |
 | `secret_name` | `PORTFOLIO_APP_PRIVATE_KEY` (informational, mirrors the wrapper contract). |
 | `branch_bypass_enabled` | Mirrors the input flag. |
@@ -75,8 +108,14 @@ Before `terraform apply`:
 
 ## Usage
 
-See [`examples/basic/`](./examples/basic/) for a runnable end-to-end
-example. The shortest possible adoption:
+Two runnable examples ship with the module:
+
+- [`examples/basic/`](./examples/basic/) shows organisation mode
+  (`organization = "nolte"`).
+- [`examples/personal-account/`](./examples/personal-account/) shows
+  user mode (`user = "octocat"`).
+
+The shortest possible adoption in organisation mode:
 
 ```hcl
 module "portfolio_app" {
@@ -100,6 +139,35 @@ module "portfolio_app" {
   enable_branch_bypass = false
 }
 ```
+
+The shortest possible adoption in user mode (same module call, swap
+`organization` for `user`):
+
+```hcl
+module "portfolio_app" {
+  source = "github.com/nolte/gh-plumbing//terraform/portfolio-app?ref=develop"
+
+  user            = "octocat"
+  app_id          = var.portfolio_app_id
+  app_slug        = "octocat-portfolio-bot"
+  app_private_key = var.portfolio_app_private_key
+
+  consumer_repositories = [
+    "my-repo-with-gh-plumbing-wrappers",
+  ]
+
+  enable_branch_bypass = false
+}
+```
+
+## When to pick which mode
+
+| Signal | Mode |
+|---|---|
+| You administer a GitHub organisation | organisation |
+| You have three or more consumer repositories | organisation (one variable + one secret cover all) |
+| You have a personal GitHub account only | user |
+| You only have one or two consumer repositories | either; user mode has lower setup overhead per consumer |
 
 ## Phase roll-out
 

--- a/terraform/portfolio-app/examples/basic/.terraform.lock.hcl
+++ b/terraform/portfolio-app/examples/basic/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "6.12.1"
+  constraints = "~> 6.6"
+  hashes = [
+    "h1:bGz4LIep/7PVrqy6P8cTYbAJpdxXGrupUJjkCczlzIs=",
+    "zh:3e1a4081ecb9518fdf0074db83c16ad00dc81ffe8249a6e3cf1894e947e28df6",
+    "zh:4cb8224b7f530795b674ac044675f6b22a7c9154f55eb9f76c5af6c7534056a4",
+    "zh:560bc08637926191f6871a89e986022ca67c70afda5bebca34b5216e6fac69c9",
+    "zh:5a70b5d2ac650c5c9819a1875411ebda229d0fcc6c9f57f9d751852ca3cd77ac",
+    "zh:8668d93bd4dc2ffa2545e1473af600a925d479b16033a71a4498a16f3b683c0c",
+    "zh:86eacc6059fd057948e178b665ba5cce74bd5488a9e1035734e60ff5ef1b6f8f",
+    "zh:a329fac98881d8dfc211a9bdc0ec6f2948f0b0c2704d1b6cbe5307403c7ad1b2",
+    "zh:dadd44abab3c52b9d572955afaef1658790e17ea355ee22b58996d81d28e02d8",
+    "zh:de9f455ef342cc38fb76bce844bfcd376fb81a4b9f9bc2fae023ff99efdf1338",
+    "zh:f8c6d2e8351b334491790358574e0a30a7c6d7f5b80f7daf32a7c0f3e9b1ab19",
+    "zh:fab41971a3edee04ab6eceaeab4eeb9a2b2f38a2af3b06eda93e2117b64994be",
+    "zh:fb1279b566dd9c8c117b2e4e0cc8344413b8fc8f2a3e24be22a9b2610551777b",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+    "zh:fe79d2a861fb9af420fa5bd7f02c031b2a0a3edf5dbc46022c8ecc7a33cf2b6d",
+  ]
+}

--- a/terraform/portfolio-app/examples/personal-account/.terraform.lock.hcl
+++ b/terraform/portfolio-app/examples/personal-account/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "6.12.1"
+  constraints = "~> 6.6"
+  hashes = [
+    "h1:bGz4LIep/7PVrqy6P8cTYbAJpdxXGrupUJjkCczlzIs=",
+    "zh:3e1a4081ecb9518fdf0074db83c16ad00dc81ffe8249a6e3cf1894e947e28df6",
+    "zh:4cb8224b7f530795b674ac044675f6b22a7c9154f55eb9f76c5af6c7534056a4",
+    "zh:560bc08637926191f6871a89e986022ca67c70afda5bebca34b5216e6fac69c9",
+    "zh:5a70b5d2ac650c5c9819a1875411ebda229d0fcc6c9f57f9d751852ca3cd77ac",
+    "zh:8668d93bd4dc2ffa2545e1473af600a925d479b16033a71a4498a16f3b683c0c",
+    "zh:86eacc6059fd057948e178b665ba5cce74bd5488a9e1035734e60ff5ef1b6f8f",
+    "zh:a329fac98881d8dfc211a9bdc0ec6f2948f0b0c2704d1b6cbe5307403c7ad1b2",
+    "zh:dadd44abab3c52b9d572955afaef1658790e17ea355ee22b58996d81d28e02d8",
+    "zh:de9f455ef342cc38fb76bce844bfcd376fb81a4b9f9bc2fae023ff99efdf1338",
+    "zh:f8c6d2e8351b334491790358574e0a30a7c6d7f5b80f7daf32a7c0f3e9b1ab19",
+    "zh:fab41971a3edee04ab6eceaeab4eeb9a2b2f38a2af3b06eda93e2117b64994be",
+    "zh:fb1279b566dd9c8c117b2e4e0cc8344413b8fc8f2a3e24be22a9b2610551777b",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+    "zh:fe79d2a861fb9af420fa5bd7f02c031b2a0a3edf5dbc46022c8ecc7a33cf2b6d",
+  ]
+}

--- a/terraform/portfolio-app/examples/personal-account/README.md
+++ b/terraform/portfolio-app/examples/personal-account/README.md
@@ -1,0 +1,52 @@
+# Personal-account example: Portfolio-app module
+
+End-to-end runnable example for a personal GitHub account (no
+organisation). The module creates per-repository Actions variables and
+secrets instead of organisation-scoped ones.
+
+## Pre-conditions
+
+- The portfolio GitHub App lives in every repository listed under
+  `consumer_repositories` (manual install per repository from the
+  App's settings page).
+- The `GITHUB_TOKEN` environment variable holds a Personal Access
+  Token with `repo` scope for the account. `admin:org` isn't needed
+  because there is no organisation.
+- `TF_VAR_portfolio_app_id` and `TF_VAR_portfolio_app_private_key`
+  carry values from your local secret manager (not committed).
+
+## Run
+
+```sh
+export GITHUB_TOKEN=ghp_...
+export TF_VAR_portfolio_app_id=1234567
+export TF_VAR_portfolio_app_private_key="$(cat ~/secrets/portfolio-app.pem)"
+
+terraform init
+terraform plan -out plan.tfplan
+terraform apply plan.tfplan
+```
+
+## Expected result
+
+- Repository-level Actions variable `PORTFOLIO_APP_ID` on every
+  repository listed under `consumer_repositories`.
+- Repository-level Actions secret `PORTFOLIO_APP_PRIVATE_KEY` on the
+  same repositories.
+- `mode` output reports `user`.
+- No branch-protection change (`enable_branch_bypass = false`).
+
+## Phase 2 follow-up
+
+Once every repository in `consumer_repositories` runs the updated
+wrapper pattern, flip `enable_branch_bypass` to `true` and re-apply.
+Terraform plan output then shows added `github_branch_protection.bypass`
+resources only.
+
+## When to prefer organisation mode
+
+If you maintain three or more consumer repositories and have an
+organisation (or can create one), organisation mode is cheaper to
+run. One organisation variable and one organisation secret with
+`visibility = "selected"` cover every consumer at once.
+Per-repository mode creates `2 × N` resources for `N` consumers.

--- a/terraform/portfolio-app/examples/personal-account/main.tf
+++ b/terraform/portfolio-app/examples/personal-account/main.tf
@@ -1,0 +1,55 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.6"
+    }
+  }
+}
+
+# Personal-account authentication. The token needs `repo` scope (to
+# create repository-level Actions variables / secrets and to manage
+# branch protection); no `admin:org` needed because there is no
+# organisation.
+provider "github" {
+  owner = "octocat"
+  # token = read from GITHUB_TOKEN env var by default
+}
+
+variable "portfolio_app_id" {
+  type = string
+}
+
+variable "portfolio_app_private_key" {
+  type      = string
+  sensitive = true
+}
+
+module "portfolio_app" {
+  source = "../.."
+
+  # User mode — set `user` instead of `organization`.
+  user            = "octocat"
+  app_id          = var.portfolio_app_id
+  app_slug        = "octocat-portfolio-bot"
+  app_private_key = var.portfolio_app_private_key
+
+  consumer_repositories = [
+    "my-repo-with-gh-plumbing-wrappers",
+  ]
+
+  # Phase 0: leave bypass off until every consumer in the list above
+  # has the App installed AND its wrappers updated. Flip to true in a
+  # follow-up apply once both are confirmed.
+  enable_branch_bypass = false
+}
+
+output "mode" {
+  value = module.portfolio_app.mode
+}
+
+output "configured" {
+  value = module.portfolio_app.configured_repositories
+}

--- a/terraform/portfolio-app/main.tf
+++ b/terraform/portfolio-app/main.tf
@@ -1,3 +1,41 @@
+# Owner resolution — exactly one of var.organization or var.user must
+# be set. Locals derive the canonical owner string used downstream for
+# repository lookups and a `is_org` flag that switches resource shape.
+locals {
+  is_org        = var.organization != ""
+  is_user       = var.user != ""
+  owner         = local.is_org ? var.organization : var.user
+  user_repo_set = local.is_user ? toset(var.consumer_repositories) : toset([])
+}
+
+# Hard-fail at plan time when both or neither owner inputs are set. A
+# null_resource with a precondition keeps the error message close to
+# the actual misconfiguration and avoids confusing Terraform with two
+# branches that both look valid.
+resource "terraform_data" "owner_check" {
+  lifecycle {
+    precondition {
+      condition     = (var.organization != "") != (var.user != "")
+      error_message = "Set exactly one of `organization` or `user`. The current configuration sets ${var.organization != "" ? "organization" : "neither"}${var.user != "" ? " and user" : ""}."
+    }
+  }
+}
+
+# Data lookup for each consumer repository — needed to translate names
+# into the numeric repo IDs the variable / secret / branch-protection
+# resources require.
+data "github_repository" "consumers" {
+  for_each  = toset(var.consumer_repositories)
+  full_name = "${local.owner}/${each.value}"
+}
+
+# --- Organisation mode ------------------------------------------------
+#
+# One org-level Actions variable + secret with visibility=selected
+# scoped to the consumer-repositories list. New consumers join by
+# extending consumer_repositories; the variable + secret cover them
+# automatically.
+
 # Org-level Actions variable holding the App ID.
 #
 # The wrapper workflows in nolte/gh-plumbing read vars.PORTFOLIO_APP_ID
@@ -5,6 +43,8 @@
 # secret) is intentional — the ID is non-sensitive and the GitHub Actions
 # `secrets` context cannot be read reliably from job-level `if:` blocks.
 resource "github_actions_organization_variable" "portfolio_app_id" {
+  count = local.is_org ? 1 : 0
+
   variable_name = "PORTFOLIO_APP_ID"
   visibility    = "selected"
   value         = var.app_id
@@ -19,6 +59,8 @@ resource "github_actions_organization_variable" "portfolio_app_id" {
 # wrapper mint a short-lived App installation token via
 # actions/create-github-app-token@v2.
 resource "github_actions_organization_secret" "portfolio_app_private_key" {
+  count = local.is_org ? 1 : 0
+
   secret_name     = "PORTFOLIO_APP_PRIVATE_KEY"
   visibility      = "selected"
   plaintext_value = var.app_private_key
@@ -27,18 +69,36 @@ resource "github_actions_organization_secret" "portfolio_app_private_key" {
   ]
 }
 
-# Data lookup for each consumer repository — needed to translate names
-# into the numeric repo IDs both organisation-secret/-variable
-# resources require.
-data "github_repository" "consumers" {
-  for_each  = toset(var.consumer_repositories)
-  full_name = "${var.organization}/${each.value}"
+# --- User mode --------------------------------------------------------
+#
+# Personal GitHub accounts have no org-level Actions variables or
+# secrets, so the module falls back to per-repository resources. New
+# consumers require explicit extension of consumer_repositories (same
+# as org mode), and Terraform creates the variable + secret on each
+# new repo on the next apply.
+
+resource "github_actions_variable" "portfolio_app_id" {
+  for_each = local.user_repo_set
+
+  repository    = each.value
+  variable_name = "PORTFOLIO_APP_ID"
+  value         = var.app_id
 }
 
-# Phase 2 (opt-in): declare the App as a push-restriction (bypass)
-# actor on each protected branch of each consumer repository. This
-# enables the workflow-driven primary path of
-# spec/project/release-automation/ §Version-bearing file alignment.
+resource "github_actions_secret" "portfolio_app_private_key" {
+  for_each = local.user_repo_set
+
+  repository      = each.value
+  secret_name     = "PORTFOLIO_APP_PRIVATE_KEY"
+  plaintext_value = var.app_private_key
+}
+
+# --- Phase 2 (opt-in): branch-protection bypass -----------------------
+#
+# Declares the App as a push-restriction (bypass) actor on each
+# protected branch of each consumer repository. Identical shape in
+# organisation and user mode — the resource keys off repo node IDs,
+# which the data lookup above already provides for both modes.
 #
 # Caveat: this only works for branches that have a protection rule. The
 # resource will create one if missing; consumers that manage branch

--- a/terraform/portfolio-app/outputs.tf
+++ b/terraform/portfolio-app/outputs.tf
@@ -1,16 +1,26 @@
+output "mode" {
+  description = "Which owner mode the module ran in — `organization` or `user`. Mirrors which input was set."
+  value       = local.is_org ? "organization" : "user"
+}
+
+output "owner" {
+  description = "The owner string (organisation or user) the module resolved at plan time."
+  value       = local.owner
+}
+
 output "configured_repositories" {
   description = "Repository names that now see the portfolio App's variable and secret. Match against var.consumer_repositories to confirm."
   value       = [for r in data.github_repository.consumers : r.name]
 }
 
 output "variable_name" {
-  description = "Name of the org-level Actions variable consumers reference (PORTFOLIO_APP_ID). Exposed for symmetry with the wrapper docs."
-  value       = github_actions_organization_variable.portfolio_app_id.variable_name
+  description = "Name of the Actions variable consumers reference (PORTFOLIO_APP_ID). Exposed for symmetry with the wrapper docs."
+  value       = "PORTFOLIO_APP_ID"
 }
 
 output "secret_name" {
-  description = "Name of the org-level Actions secret consumers reference (PORTFOLIO_APP_PRIVATE_KEY). Exposed for symmetry with the wrapper docs."
-  value       = github_actions_organization_secret.portfolio_app_private_key.secret_name
+  description = "Name of the Actions secret consumers reference (PORTFOLIO_APP_PRIVATE_KEY). Exposed for symmetry with the wrapper docs."
+  value       = "PORTFOLIO_APP_PRIVATE_KEY"
 }
 
 output "branch_bypass_enabled" {

--- a/terraform/portfolio-app/variables.tf
+++ b/terraform/portfolio-app/variables.tf
@@ -1,10 +1,17 @@
 variable "organization" {
-  description = "GitHub organisation (or user) that owns the consumer repositories. The provider must be authenticated against this scope."
+  description = "GitHub organisation that owns the consumer repositories. Mutually exclusive with var.user — set exactly one. Org mode provisions one org-level variable + secret with visibility=selected; user mode provisions repo-level variables + secrets per consumer repository."
   type        = string
+  default     = ""
+}
+
+variable "user" {
+  description = "GitHub user account that owns the consumer repositories. Mutually exclusive with var.organization — set exactly one. Used when no GitHub organisation exists; the module then creates per-repository Actions variables and secrets instead of organisation-scoped ones."
+  type        = string
+  default     = ""
 }
 
 variable "app_id" {
-  description = "Numeric ID of the portfolio GitHub App (visible on its settings page). Written to the org-level Actions variable PORTFOLIO_APP_ID."
+  description = "Numeric ID of the portfolio GitHub App (visible on its settings page). Written to the Actions variable PORTFOLIO_APP_ID — org-scoped in organisation mode, repo-scoped in user mode."
   type        = string
 
   validation {
@@ -14,7 +21,7 @@ variable "app_id" {
 }
 
 variable "app_private_key" {
-  description = "PEM-encoded private key for the portfolio GitHub App. Written to the org-level Actions secret PORTFOLIO_APP_PRIVATE_KEY. Marked sensitive."
+  description = "PEM-encoded private key for the portfolio GitHub App. Written to the Actions secret PORTFOLIO_APP_PRIVATE_KEY — org-scoped in organisation mode, repo-scoped in user mode. Marked sensitive."
   type        = string
   sensitive   = true
 
@@ -35,7 +42,7 @@ variable "app_slug" {
 }
 
 variable "consumer_repositories" {
-  description = "Names of repositories in var.organization that should consume the portfolio App. The module sets visibility=selected on the org-level variable + secret to this list, and (when enable_branch_bypass is true) configures branch protection with the App as a bypass actor."
+  description = "Names of repositories under the owner (organisation or user) that should consume the portfolio App. Org mode sets visibility=selected on the org-level variable + secret to this list; user mode creates one variable + secret per repository here. When enable_branch_bypass is true, every listed repo also gets the App declared as a push-restriction actor."
   type        = list(string)
 
   validation {
@@ -45,7 +52,7 @@ variable "consumer_repositories" {
 }
 
 variable "enable_branch_bypass" {
-  description = "When true, configure branch protection on var.protected_branches for every consumer repository with var.app_slug declared as a push-restriction (bypass) actor. This is Phase 2 of issue #330. Default off so Phase 0 (credentials + selection) can land independently."
+  description = "When true, configure branch protection on var.protected_branches for every consumer repository with var.app_slug declared as a push-restriction (bypass) actor. This is Phase 2 of issue #330. Default off so Phase 0 (credentials + selection) can land independently. Works identically in organisation and user mode."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
## Summary

Adds personal-account support to `terraform/portfolio-app/` so
consumers don't need a GitHub organisation to adopt gh-plumbing.
Backwards-compatible with the org-mode shipped in #350.

## Changes

- `variables.tf` — `organization` becomes optional (default `""`);
  new `user` input (default `""`); exactly-one validation message
  documented on both.
- `main.tf` — locals derive `owner` and `is_org` flag; new
  `terraform_data.owner_check` precondition fails fast on a
  half-configured input pair; org-resources gated on `count =
  local.is_org ? 1 : 0`; new per-repository `github_actions_variable`
  and `github_actions_secret` resources gated on
  `for_each = local.user_repo_set`; branch-protection bypass logic
  unchanged (works identically in both modes).
- `outputs.tf` — new `mode` (`"organization"` | `"user"`) and `owner`
  outputs; existing outputs adapted to the new shape.
- `examples/personal-account/` — new runnable example for a personal
  account with its own README (pre-conditions, run, expected result,
  when-to-prefer-org hint).
- `README.md` — new "Owner modes" section side-by-side;
  per-mode provider scopes; usage snippets for both modes; "when to
  pick which mode" decision table.

## Linked issues

Refs #330

## Testing

- `terraform fmt -recursive` — clean.
- `terraform init -backend=false && terraform validate` — `Success!
  The configuration is valid.` for module, `examples/basic/`, and
  `examples/personal-account/`.
- `vale --minAlertLevel=suggestion` on both READMEs — 0/0/0.
- `mkdocs build --strict` — both `en` and `de` trees build cleanly.
- `pre-commit run --all-files` — all hooks green.

## Risk / rollout notes

Low. The module gains an additive code path; the existing org-mode
behaviour is unchanged. Consumers of the previously-merged module
(only `examples/basic/`) keep working without touching their HCL.

Half-configured input states (both `organization` and `user` set, or
neither set) fail fast at plan time with a specific error message
naming which input pair is wrong — no apply runs against a
half-state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)