### PR TITLE
docs(portfolio-app): make user-account mode visible in MkDocs site

### DIFF
--- a/docs/de/index.md
+++ b/docs/de/index.md
@@ -36,6 +36,14 @@
 
     [:octicons-arrow-right-24: Probot-Konfigurationen](probot/index.md)
 
+-   :material-key-variant: **Portfolio-App**
+
+    ---
+
+    Zentrale GitHub App, die die `GITHUB_TOKEN`-Cascade-Lücke schließt. Funktioniert für Organisationen und persönliche Accounts; Terraform-Modul inklusive.
+
+    [:octicons-arrow-right-24: Setup](portfolio-app/setup.md)
+
 -   :material-wrench: **Entwicklung**
 
     ---

--- a/docs/de/portfolio-app/setup.md
+++ b/docs/de/portfolio-app/setup.md
@@ -29,6 +29,27 @@ personengebundenes Credential.
 
 ---
 
+## Owner-Modi
+
+Die Portfolio-App kann Konsumenten unter einer GitHub-**Organisation**
+oder unter einem persönlichen **User-Account** bedienen. Wähle den
+Modus, der zum Account passt, der die Konsumenten-Repositories
+besitzt — beide Modi liefern dasselbe nachgelagerte Verhalten
+(App-emittierte Events kaskadieren user-initiated), nur die
+Credential-Verkabelung unterscheidet sich.
+
+| Modus | Wann wählen | Credentials liegen als |
+|---|---|---|
+| Organisations-Modus | Der Account, der die Konsumenten-Repositories besitzt, ist eine GitHub-Organisation. Günstiger im Betrieb ab drei Konsumenten. | Eine Org-Level-Actions-Variable + ein Org-Level-Actions-Secret mit `visibility = "selected"`, beschränkt auf die Konsumenten-Liste. |
+| User-Modus | Der Account, der die Konsumenten-Repositories besitzt, ist ein persönlicher GitHub-Account (keine Org). | Eine Repo-Level-Actions-Variable + ein Repo-Level-Actions-Secret in jedem Konsumenten-Repository. |
+
+Beide Modi nutzen dasselbe Wrapper-Pattern in `.github/workflows/`;
+die Wrapper interessiert nicht, welcher Modus ihr
+`PORTFOLIO_APP_ID` / `PORTFOLIO_APP_PRIVATE_KEY`-Paar gesetzt hat,
+sondern nur, dass das Paar zum Job-Start eine gültige App ergibt.
+
+---
+
 ## Welche Permissions die App braucht
 
 Bei der Registrierung exakt diese Repository-Permissions vergeben:
@@ -64,23 +85,35 @@ Installation-Token holen.
 5. **App installieren** in jedem Konsument-Repository, das
    cascade-korrekte Workflows braucht. Beginne mit
    `nolte/gh-plumbing` selbst.
-6. **Repository- (oder Organisations-) Credentials setzen** auf jedem
-   Konsumenten, der die App adoptiert:
-   - Variable `PORTFOLIO_APP_ID` (Organisations- oder Repo-
-     [Actions-Variable](https://docs.github.com/en/actions/learn-github-actions/variables)) —
-     die App-ID ist nicht sensibel; als Variable abgelegt kann die
-     `if:`-Condition im Wrapper die Adoption erkennen.
-   - Secret `PORTFOLIO_APP_PRIVATE_KEY` (Organisations- oder Repo-
-     [Actions-Secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets)) —
-     der vollständige PEM-Inhalt aus Schritt 3.
+6. **Credentials setzen** im Scope, der zum Owner-Modus passt:
+   - **Organisations-Modus:** eine
+     [Org-Level-Actions-Variable](https://docs.github.com/en/actions/learn-github-actions/variables)
+     `PORTFOLIO_APP_ID` und ein
+     [Org-Level-Actions-Secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
+     `PORTFOLIO_APP_PRIVATE_KEY`, beide mit `visibility = "selected"`
+     auf die Konsumenten-Liste eingeschränkt.
+   - **User-Modus:** eine Repo-Level-Actions-Variable
+     `PORTFOLIO_APP_ID` und ein Repo-Level-Actions-Secret
+     `PORTFOLIO_APP_PRIVATE_KEY` in **jedem** Konsumenten-Repository.
+     Persönliche Accounts bieten keine Org-Level-Actions-Resourcen,
+     daher trägt jedes Repository sein eigenes Paar.
+
+   Die App-ID ist nicht sensibel; als Variable abgelegt kann die
+   `if:`-Condition im Wrapper die Adoption erkennen. Der
+   Private-Key-Inhalt aus Schritt 3 landet im Secret.
 
 !!! tip "Terraform-getriebene Provisionierung"
     Die Schritte 5 und 6 sind auch als Terraform-Modul unter
     [`terraform/portfolio-app/`](https://github.com/nolte/gh-plumbing/tree/develop/terraform/portfolio-app)
-    verfügbar. Das Modul legt die Org-Variable und das Org-Secret in
-    einem `terraform apply` an und deklariert optional die App als
-    Branch-Protection-Bypass-Actor. Schritte 1–4 bleiben manuell, weil
-    GitHub keine API zur App-Erstellung anbietet.
+    verfügbar. Das Modul unterstützt beide Modi (Organisation und
+    User), legt Variable und Secret in einem `terraform apply` an und
+    deklariert optional die App als Branch-Protection-Bypass-Actor.
+    Schritte 1–4 bleiben manuell, weil GitHub keine API zur
+    App-Erstellung anbietet. Siehe
+    [`examples/basic/`](https://github.com/nolte/gh-plumbing/tree/develop/terraform/portfolio-app/examples/basic)
+    für den Organisations-Modus und
+    [`examples/personal-account/`](https://github.com/nolte/gh-plumbing/tree/develop/terraform/portfolio-app/examples/personal-account)
+    für den User-Modus.
 
 ---
 
@@ -157,11 +190,14 @@ selbst triggern:
 Wenn ein Cascade immer noch nicht triggert, prüfe:
 
 1. Die App ist im Konsument-Repo installiert (`Settings → GitHub Apps`).
-2. `vars.PORTFOLIO_APP_ID` ist für den Workflow sichtbar (Repo- oder
-   Org-Variable-Scope passt zum Workflow-Repo).
-3. Der Wrapper-Run zeigt den `mint-token`-Job als `success` mit dem
-   `app-token`-Step **executed** (nicht skipped). Skipped Step =
-   Fallback-Pfad = GITHUB_TOKEN = Cascade-Lücke.
+2. `vars.PORTFOLIO_APP_ID` ist für den Workflow sichtbar.
+   Organisations-Modus: die Org-Variable hat `visibility = "selected"`
+   inklusive des Workflow-Repos. User-Modus: das Repository trägt
+   seine eigene `PORTFOLIO_APP_ID`-Actions-Variable.
+3. Der reusable-Run zeigt den `Mint App installation token`-Step als
+   `success` (nicht `skipped`). Skipped Step bedeutet, der App-ID-Input
+   war leer und der Fallback-Pfad griff (`GITHUB_TOKEN` =
+   Cascade-Lücke).
 
 ---
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -36,6 +36,14 @@
 
     [:octicons-arrow-right-24: Probot configurations](probot/index.md)
 
+-   :material-key-variant: **Portfolio App**
+
+    ---
+
+    Centralised GitHub App that closes the `GITHUB_TOKEN` cascade gap. Works for organisations and personal accounts. Terraform module included.
+
+    [:octicons-arrow-right-24: Setup](portfolio-app/setup.md)
+
 -   :material-wrench: **Development**
 
     ---

--- a/docs/en/portfolio-app/setup.md
+++ b/docs/en/portfolio-app/setup.md
@@ -29,6 +29,26 @@ Personal-Access-Token collection, no person-bound credential.
 
 ---
 
+## Owner modes
+
+The portfolio App can serve consumers under a GitHub **organisation**
+or under a personal **user** account. Pick the mode that matches the
+account that owns the consumer repositories. Both modes give the same
+downstream behaviour: App-authored events cascade user-initiated.
+Only the credential plumbing differs.
+
+| Mode | When to pick | Credentials live as |
+|---|---|---|
+| Organisation mode | The account owning consumer repositories is a GitHub organisation. Cheaper to operate when three or more consumers exist. | One organisation-level Actions variable + one organisation-level Actions secret with `visibility = "selected"` scoped to the consumer-repositories list. |
+| User mode | The account owning consumer repositories is a personal GitHub account (no organisation). | One repository-level Actions variable + one repository-level Actions secret on each consumer repository. |
+
+Both modes use the same wrapper pattern in `.github/workflows/`. The
+wrappers don't care which mode set their `PORTFOLIO_APP_ID` /
+`PORTFOLIO_APP_PRIVATE_KEY` pair, only that the pair resolves to a
+valid App at job start.
+
+---
+
 ## Permissions the app requires
 
 When you register the App, grant exactly these repository permissions:
@@ -61,23 +81,34 @@ token at job start use the App exclusively.
 4. **Note the App ID** (visible on the App's settings page).
 5. **Install the App** in every consumer repository that needs
    cascade-correct workflows. Start with `nolte/gh-plumbing` itself.
-6. **Set repository (or organisation) credentials** on each consumer
-   that adopts the App:
-   - Variable `PORTFOLIO_APP_ID` (organisation- or repository-level
-     [Actions variable](https://docs.github.com/en/actions/learn-github-actions/variables)).
-     The App ID isn't sensitive; storing it as a variable lets the
-     wrapper `if:` condition detect adoption.
-   - Secret `PORTFOLIO_APP_PRIVATE_KEY` (organisation- or repository-level
-     [Actions secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets))
-     holding the full private-key contents from step 3.
+6. **Set credentials** at the scope that matches the owner mode:
+   - **Organisation mode:** one
+     [organisation-level Actions variable](https://docs.github.com/en/actions/learn-github-actions/variables)
+     `PORTFOLIO_APP_ID` and one
+     [organisation-level Actions secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
+     `PORTFOLIO_APP_PRIVATE_KEY`, both with `visibility = "selected"`
+     scoped to the consumer-repositories list.
+   - **User mode:** one repository-level Actions variable
+     `PORTFOLIO_APP_ID` and one repository-level Actions secret
+     `PORTFOLIO_APP_PRIVATE_KEY` on **every** consumer repository.
+     Personal accounts don't expose org-level Actions resources, so
+     each repository carries its own pair.
+
+   The App ID isn't sensitive. Storing it as a variable lets the
+   wrapper `if:` condition detect adoption. The private-key contents
+   from step 3 go into the secret.
 
 !!! tip "Terraform-driven provisioning"
     Steps 5 and 6 are also available as a Terraform module under
     [`terraform/portfolio-app/`](https://github.com/nolte/gh-plumbing/tree/develop/terraform/portfolio-app).
-    The module creates the org-level variable and secret in one
-    `terraform apply` and (optionally) declares the App as a
-    branch-protection bypass actor. Steps 1–4 stay manual because
-    GitHub provides no API to create an App.
+    The module supports both organisation and user mode, creates the
+    variable and secret in one `terraform apply`, and (optionally)
+    declares the App as a branch-protection bypass actor. Steps 1–4
+    stay manual because GitHub provides no API to create an App. See
+    [`examples/basic/`](https://github.com/nolte/gh-plumbing/tree/develop/terraform/portfolio-app/examples/basic)
+    for organisation mode and
+    [`examples/personal-account/`](https://github.com/nolte/gh-plumbing/tree/develop/terraform/portfolio-app/examples/personal-account)
+    for user mode.
 
 ---
 
@@ -144,9 +175,10 @@ After provisioning and adoption, both cascade chains should self-trigger:
 If a cascade still fails to fire, check:
 
 1. Confirm the App install in the consumer repository (`Settings → GitHub Apps`).
-2. Confirm `vars.PORTFOLIO_APP_ID` is visible to the workflow
-   (repository or organisation variable scope matches the workflow's
-   repository).
+2. Confirm `vars.PORTFOLIO_APP_ID` is visible to the workflow.
+   Organisation mode: the org-level variable's `visibility = "selected"`
+   list includes the workflow's repository. User mode: the repository
+   carries its own `PORTFOLIO_APP_ID` Actions variable.
 3. The reusable run shows the `Mint App installation token` step as
    `success`, not `skipped`. A skipped step means the App-id input
    arrived empty and the fallback path took over (`GITHUB_TOKEN` =


### PR DESCRIPTION
## Summary

Closes the audience-coverage gap that surfaced after #351: the
user-account mode lived solely in the Terraform module README.
Audience C (personal-account adopters) had to chase the Terraform
tip-box link before they could find their provisioning path.

## Changes

- `docs/{en,de}/portfolio-app/setup.md`
  - New **Owner modes** section right after "Why it exists" with a
    side-by-side decision table (Organisation mode vs. User mode).
  - Provisioning checklist **step 6 split per mode** — organisation
    mode keeps the visibility-selected org-variable + org-secret pair;
    user mode shows the per-repository variable + secret pair.
  - Verification **step 2 split per mode** so operators know which
    scope to check.
  - Terraform tip-box now mentions both modes and links at
    `examples/basic/` and `examples/personal-account/`.
- `docs/{en,de}/index.md`
  - New **Portfolio-App** home card so the page is reachable from the
    landing page (was reachable only through the side nav).

## Linked issues

Refs #330
Refs #351

## Testing

- `vale --minAlertLevel=suggestion docs/en/portfolio-app/setup.md docs/en/index.md` — 0 errors, 0 warnings, 0 suggestions.
- `mkdocs build --strict` — both `en` and `de` trees build cleanly.
- `pre-commit run --all-files` — all hooks green.
- Manual spot-check: EN and DE setup.md both carry the new section;
  EN and DE index.md both show the new card.

## Risk / rollout notes

Pure content addition. No structural changes to the docs site
(`docs_dir`, nav titles, plugin order all unchanged). Existing
deep-links into `portfolio-app/setup.md` keep working — the new
"Owner modes" section is inserted before the existing
"Permissions the app requires" heading; no anchor renames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)