### PR TITLE
fix(taskfile): repoint includes from deleted branch to develop

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,7 +3,13 @@
 version: '3'
 
 vars:
-  TASK_COLLECTION_BASE: https://raw.githubusercontent.com/nolte/taskfiles/fix/py-var-names/src
+  # Follows the default branch of nolte/taskfiles. The previous pin
+  # (`fix/py-var-names`) was a feature branch that has since been
+  # deleted upstream after merge; deletion of the source branch yields
+  # 404 on every `task` invocation here. Tracking `develop` is the
+  # baseline until upstream produces a tag that ships both
+  # taskfile-include-mkdocs.yaml AND taskfile-include-pre-commit.yaml.
+  TASK_COLLECTION_BASE: https://raw.githubusercontent.com/nolte/taskfiles/develop/src
 
 includes:
   mkdocs: "{{.TASK_COLLECTION_BASE}}/taskfile-include-mkdocs.yaml"


### PR DESCRIPTION
## Summary

`Taskfile.yml` pinned `TASK_COLLECTION_BASE` at the upstream feature
branch `nolte/taskfiles@fix/py-var-names`. That branch was deleted
after merge; every `task` invocation now fails with `404` while
fetching the remote include files.

## Changes

- `Taskfile.yml` — point `TASK_COLLECTION_BASE` at the upstream
  default branch (`develop`) instead of the deleted feature branch.
  Comment block explains why a version-tag pin isn't viable yet
  (latest tag `v0.1.3` ships `taskfile-include-mkdocs.yaml` only,
  not `taskfile-include-pre-commit.yaml`).

## Linked issues

None

## Testing

Local repro of the failure mode:

```
$ task -l
task: Download of "https://raw.githubusercontent.com/nolte/taskfiles/
fix/py-var-names/src/taskfile-include-mkdocs.yaml" failed with status
code 404 (Not Found)
```

After the fix:

```
$ task -l
mkdocs:start
pre-commit:install
pre-commit:start
```

Both remote includes (mkdocs + pre-commit) resolve `200 OK` against
`nolte/taskfiles@develop/src/`.

## Risk / rollout notes

Low. Single-line URL repointing. Affects local development only —
gh-plumbing CI uses `pre-commit` and `mkdocs` directly, not through
the Taskfile. No consumer-visible change.

Trade-off: tracking the upstream `develop` branch instead of a tag
means a future breaking change in `nolte/taskfiles` can break local
`task` invocations without warning. Acceptable because both repos
live in the same org; switch to a tag pin once upstream cuts a
release that ships both include files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)