### PR TITLE
docs(portfolio-app): document App registration form fields in detail

### DIFF
--- a/docs/de/portfolio-app/setup.md
+++ b/docs/de/portfolio-app/setup.md
@@ -52,23 +52,52 @@ sondern nur, dass das Paar zum Job-Start eine gültige App ergibt.
 
 ## Welche Permissions die App braucht
 
-Bei der Registrierung exakt diese Repository-Permissions vergeben:
+Bei der Registrierung exakt diese **Repository permissions**
+vergeben:
 
 | Permission | Scope | Wofür |
 |---|---|---|
-| `Contents` | `Read & write` | Squash-Merge nach develop, Releases editieren, master fast-forwarden |
-| `Pull requests` | `Read & write` | `pascalgn/automerge-action` liest und merged PRs |
-| `Actions` | `Read` | `release-publish` liest `gh run list` für den Post-Publish-Cascade-Check |
-| `Metadata` | `Read` | Pflicht-Basis |
+| `Contents` | `Read and write` | Squash-Merge nach develop, Releases editieren, master fast-forwarden |
+| `Pull requests` | `Read and write` | `pascalgn/automerge-action` liest und merged PRs |
+| `Actions` | `Read-only` | `release-publish` liest `gh run list` für den Post-Publish-Cascade-Check |
+| `Metadata` | `Read-only` | Pflicht-Basis (setzt GitHub automatisch und lässt sich nicht abwählen) |
 
-Sonst nichts. Insbesondere: keine `Administration`-Permission (die
-Repository-Settings-App ist ein eigenständiger Service), keine
-`Workflows`-Permission (nur nötig, wenn die App Dateien unter
-`.github/workflows/` editiert).
+**Jede andere Repository-Permission** bleibt auf `No access`,
+insbesondere die drei, die verwandt klingen, aber keine sind:
 
-Webhook wird nicht gebraucht — die App wird ausschließlich aus
-Workflow-Runs konsumiert, die zu Beginn eines Jobs ein
-Installation-Token holen.
+| Permission | Setting | Wieso NICHT |
+|---|---|---|
+| `Administration` | `No access` | Die Probot Settings App verwaltet Repo-Konfiguration. Diese Permission hier zu setzen erhöht nur die Angriffsfläche, ohne Nutzen. |
+| `Workflows` | `No access` | Würde der App erlauben, `.github/workflows/*.yaml` zu überschreiben. Unsere Use-Case merged Branches und Releases, keine Workflow-Dateien. Später aktivieren, falls jemals nötig. |
+| `Issues` | `No access` | Die App liest und schreibt keine Issues. |
+
+**Alle Organization permissions** und **alle Account permissions**
+bleiben auf `No access` — die Arbeit der App ist repo-scoped.
+
+### Identifying and authorizing users
+
+Diese ganze Sektion bleibt aus. Unsere App agiert über
+Installation-Tokens, die in Workflow-Runs gemintet werden, niemals
+im Namen eines Endnutzers:
+
+- **Callback URL** bleibt leer (`Delete` auf den Platzhalter klicken).
+- **Request user authorization (OAuth) during installation** bleibt
+  ungesetzt.
+- **Enable Device Flow** bleibt ungesetzt.
+- **Expire user authorization tokens** ist egal; GitHub setzt es
+  vor, aber wir geben keine User-Tokens aus, die ablaufen könnten.
+
+### Webhook
+
+Webhook komplett deaktivieren (**Active** abwählen). Die App wird
+ausschließlich aus Workflow-Runs konsumiert, die zu Beginn eines
+Jobs ein Installation-Token holen — keine Event-Subscriptions
+notwendig und kein Endpoint vorhanden, der sie entgegennimmt.
+
+### Subscribe to events
+
+In der Event-Liste der App **keinen einzigen Event** abonnieren.
+Jedes aktivierte Häkchen würde nur tote Webhook-Versuche erzeugen.
 
 ---
 

--- a/docs/en/portfolio-app/setup.md
+++ b/docs/en/portfolio-app/setup.md
@@ -51,21 +51,51 @@ valid App at job start.
 
 ## Permissions the app requires
 
-When you register the App, grant exactly these repository permissions:
+When you register the App, grant exactly these **Repository
+permissions**:
 
 | Permission | Scope | Why |
 |---|---|---|
-| `Contents` | `Read & write` | squash-merge to develop, edit releases, fast-forward master |
-| `Pull requests` | `Read & write` | `pascalgn/automerge-action` reads and merges PRs |
-| `Actions` | `Read` | `release-publish` reads `gh run list` for the post-publish cascade sanity check |
-| `Metadata` | `Read` | mandatory baseline |
+| `Contents` | `Read and write` | Squash-merge to develop, edit releases, fast-forward master |
+| `Pull requests` | `Read and write` | `pascalgn/automerge-action` reads and merges PRs |
+| `Actions` | `Read-only` | `release-publish` reads `gh run list` for the post-publish cascade sanity check |
+| `Metadata` | `Read-only` | Mandatory baseline (GitHub sets this automatically and won't let you disable it) |
 
-Nothing else. In particular: no `Administration` permission (the
-repository-settings App is a separate service), no `Workflows`
-permission (only needed if the App edits `.github/workflows/` files).
+Leave **every other Repository permission** on `No access`, in
+particular the three that look related but aren't:
 
-A webhook isn't required—workflow runs that mint an installation
-token at job start use the App exclusively.
+| Permission | Setting | Reason to skip |
+|---|---|---|
+| `Administration` | `No access` | The Probot Settings App owns repository configuration. Granting this here adds attack surface for no gain. |
+| `Workflows` | `No access` | Would let the App rewrite `.github/workflows/*.yaml`. The use case in this repository merges branches and releases, not workflow files. Add later only if a future reusable needs it. |
+| `Issues` | `No access` | The App neither reads nor writes issues. |
+
+Leave **all Organization permissions** and **all Account permissions**
+on `No access`. The App's work is repository-scoped.
+
+### Identifying and authorizing users
+
+Leave this entire section off. The App acts through installation
+tokens minted in workflow runs, never on behalf of an end user:
+
+- **Callback `URL`** stays empty (`Delete` the placeholder).
+- **Request user authorization (`OAuth`) during installation** stays
+  unchecked.
+- **Enable Device Flow** stays unchecked.
+- **Expire user authorization tokens** is irrelevant either way;
+  GitHub pre-checks it, but the App issues no user tokens to expire.
+
+### Webhook
+
+Disable the webhook entirely (clear the **Active** checkbox). The App
+runs exclusively inside workflow runs that mint an installation token
+at job start. The App subscribes to no events and exposes no endpoint
+to receive them.
+
+### Subscribe to events
+
+Subscribe to **no events** in the App's event list. Leaving any
+subscription on would only generate dead webhook attempts.
 
 ---
 


### PR DESCRIPTION
## Summary

`portfolio-app/setup.md` listed the four required Repository
permissions but stayed silent on every surrounding field of the
GitHub App registration form. Operators registering the App for the
first time had to guess (or ask in chat) what to do with the
"Identifying and authorizing users" block, the Webhook block, the
event subscriptions, and which other Repository permissions look
related but should stay off. This PR closes those gaps.

## Changes

- `docs/{en,de}/portfolio-app/setup.md` §Permissions the app requires
  - Explicit "Reason to skip" table for the three Repository permissions
    that look related but must stay on `No access`: `Administration`,
    `Workflows`, `Issues`.
  - Statement that **all** Organization permissions and **all** Account
    permissions stay on `No access`.
  - New subsection §"Identifying and authorizing users" — Callback
    URL empty, both OAuth checkboxes off, "Expire user authorization
    tokens" pre-check noted as irrelevant.
  - New subsection §"Webhook" — clear the **Active** checkbox.
  - New subsection §"Subscribe to events" — subscribe to nothing.

EN and DE pages get the same edits.

## Linked issues

Refs #330

## Testing

- `vale --minAlertLevel=suggestion docs/en/portfolio-app/setup.md` — 0/0/0.
- `mkdocs build --strict` — both `en` and `de` trees build cleanly.
- `pre-commit run --all-files` — all hooks green.

## Risk / rollout notes

Pure content addition. No headings renamed; existing anchors stay
valid. The new subsections sit under the existing §Permissions the
app requires heading and are introduced as `###` subsections, so
they don't change top-level navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)