### PR TITLE
feat(commons): declare portfolio App as branch-protection bypass actor (Phase 2 of #330)

### DIFF
--- a/.github/commons-settings.yml
+++ b/.github/commons-settings.yml
@@ -142,7 +142,25 @@ branches:
       required_pull_request_reviews: null
       required_status_checks: null
       enforce_admins: true
-      restrictions: null
+      # nolte-portfolio-app is the portfolio GitHub App that the cascade
+      # remediation in #330 (Phase 1) wires through every cascade-emitting
+      # reusable workflow. Declaring it as a push restriction actor here
+      # enables the workflow-driven primary path of
+      # spec/project/release-automation/ §Version-bearing file alignment:
+      # `reusable-release-cd-refresh-master.yml` fast-forwards master with
+      # the App token, and the push event cascades to other workflows.
+      #
+      # Consumers that own a personal account (not an organisation) cannot
+      # honour `restrictions.apps` (GitHub limits this to organisation-owned
+      # repositories); the Probot Settings App will skip the field silently
+      # for those repositories. Such consumers either operate without
+      # restrictions or override this block in their per-repo
+      # .github/settings.yml.
+      restrictions:
+        users: []
+        teams: []
+        apps:
+          - nolte-portfolio-app
   - name: develop
     protection:
       required_pull_request_reviews: null
@@ -155,4 +173,8 @@ branches:
         strict: true
         contexts: []
       enforce_admins: true
-      restrictions: null
+      restrictions:
+        users: []
+        teams: []
+        apps:
+          - nolte-portfolio-app

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -7,9 +7,11 @@
 # file as well (a comment touch is enough) so the App re-runs the merge.
 # Tracked by https://github.com/nolte/gh-plumbing/issues/331.
 #
-# Last propagation: 2026-05-01 — drift cleanup (rename `documentations` →
-# `documentation`, add `stale` and `github-actions`, simplify `release`
-# description).
+# Last propagation: 2026-05-20 — Phase 2 of #330: declare
+# nolte-portfolio-app as branch-protection bypass actor on develop and
+# master (push_restrictions actor) so the workflow-driven primary path
+# of spec/project/release-automation/ §Version-bearing file alignment
+# becomes usable.
 
 _extends: gh-plumbing:.github/commons-settings.yml
 

--- a/docs/de/portfolio-app/setup.md
+++ b/docs/de/portfolio-app/setup.md
@@ -241,18 +241,45 @@ Wenn ein Cascade immer noch nicht triggert, prüfe:
 
 ---
 
-## Branch-Protection-Bypass (Folgearbeit)
+## Branch-Protection-Bypass (Phase 2)
 
-Die Spec verlangt außerdem, die App in `commons-settings.yml` als
-Bypass-Actor für Branch-Protection zu deklarieren, damit der
-workflow-getriebene Primary Path aus
-`spec/project/release-automation/` §Version-bearing file alignment
-nutzbar wird. Diese Änderung verdrahtet die App über `_extends` in die
-`develop`- und `master`-Branch-Protection jedes Konsumenten.
+`commons-settings.yml` deklariert die App als Push-Restriction-Actor
+auf den Branches `develop` und `master`. Da Konsumenten-Repositories
+die Commons per `_extends:` einbinden, propagiert der Bypass
+automatisch zu jedem Adopter, sobald die App in dessen Repository
+installiert ist.
 
-Sie ist absichtlich **nicht** Teil dieses initialen PRs. Ein separater
-PR fügt den Bypass-Eintrag ein, sobald die App registriert ist und du
-ihren App-Slug eintragen kannst.
+Der konfigurierte Slug ist **`nolte-portfolio-app`**:
+
+```yaml title=".github/commons-settings.yml"
+branches:
+  - name: develop
+    protection:
+      enforce_admins: true
+      restrictions:
+        users: []
+        teams: []
+        apps:
+          - nolte-portfolio-app
+```
+
+Derselbe Block gilt für `master`.
+
+!!! warning "Persönliche Accounts unterstützen `restrictions.apps` nicht"
+    GitHub beschränkt `restrictions.users` / `.teams` / `.apps` auf
+    Organisations-Repositories. Die Probot Settings App überspringt
+    das Feld still, wenn es in einem persönlichen Account landet.
+    Persönliche-Account-Konsumenten arbeiten entweder ohne
+    Push-Restriktionen oder überschreiben den Branches-Block in
+    ihrem per-Repo-`.github/settings.yml`.
+
+!!! tip "Vorbedingung für Phase 2"
+    Vor dem Merge des Phase-2-PRs muss die App bereits in jedem
+    Konsumenten-Repository installiert sein, dessen
+    `commons-settings.yml` den Bypass erhält. Eine nicht installierte
+    App kann nichts bypassen; der einzige Effekt einer zu frühen
+    Phase 2 wäre, direkte Pushes von allen anderen Actors zu
+    blockieren.
 
 ---
 

--- a/docs/en/portfolio-app/setup.md
+++ b/docs/en/portfolio-app/setup.md
@@ -227,18 +227,44 @@ If a cascade still fails to fire, check:
 
 ---
 
-## Branch-protection bypass (future work)
+## Branch-protection bypass (phase 2)
 
-The spec also calls for declaring the App as a branch-protection
-bypass actor in `commons-settings.yml` so that the workflow-driven
-primary path of
-`spec/project/release-automation/` §Version-bearing file alignment
-becomes usable. That change wires the App into every consumer's
-`develop` and `master` branch protection through `_extends`.
+`commons-settings.yml` declares the App as a push-restriction actor
+on the `develop` and `master` branches. Because consumer repositories
+extend the commons through `_extends:`, the bypass propagates to
+every adopter automatically once the App reaches an installation in
+their repository.
 
-This change isn't part of the initial PR. A separate PR lands
-the bypass entry once you have the App registered and can fill in
-its App slug.
+The configured slug is **`nolte-portfolio-app`**:
+
+```yaml title=".github/commons-settings.yml"
+branches:
+  - name: develop
+    protection:
+      enforce_admins: true
+      restrictions:
+        users: []
+        teams: []
+        apps:
+          - nolte-portfolio-app
+```
+
+The same block applies to `master`.
+
+!!! warning "Personal accounts can't honour `restrictions.apps`"
+    GitHub limits `restrictions.users` / `.teams` / `.apps` to
+    organisation-owned repositories. The Probot Settings App skips
+    the field without error when it lands in a personal-account
+    repository. Personal-account consumers either operate without
+    push restrictions or override the branches block in their
+    per-repo `.github/settings.yml`.
+
+!!! tip "Pre-condition for phase 2"
+    Before merging the phase-2 PR, the App must already live in
+    every consumer repository whose `commons-settings.yml` will
+    receive the bypass. An App that hasn't reached the repository
+    can't bypass anything. The only effect of an early phase 2 is to
+    block direct pushes from any other actor.
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 2 of #330. Wires `nolte-portfolio-app` (App ID `3784868`) into
the `develop` and `master` branch protections of every consumer that
extends `nolte/gh-plumbing:.github/commons-settings.yml`. This is the
**pre-condition** for the workflow-driven primary path of
`spec/project/release-automation/` §Version-bearing file alignment:
the App token, minted inside `reusable-release-cd-refresh-master.yml`
and the alignment-commit flow, then has the right to push to develop
and master through the branch protection.

## Changes

- `.github/commons-settings.yml`
  - `develop` and `master` branch protection extended with
    `restrictions.apps: [nolte-portfolio-app]`.
  - Inline comment block explains why the bypass exists and that
    personal-account consumers can't honour the field (GitHub limits
    push-restriction actors to organisation-owned repositories — the
    Probot Settings App skips the field for those).
- `.github/settings.yml`
  - Propagation comment bumped per the Probot-Settings sync rule
    documented in #331. `commons-*` changes don't propagate without a
    touch on the consumer's `settings.yml`.
- `docs/{en,de}/portfolio-app/setup.md`
  - "Branch-protection bypass (future work)" placeholder replaced with
    a concrete "Phase 2" section including the configured slug, the
    personal-account caveat, and the pre-condition box that the App
    must already live in every consumer repository before this
    bypass takes effect.

## Linked issues

Refs #330

## Testing

- `mkdocs build --strict` — both `en` and `de` trees build cleanly.
- `vale --minAlertLevel=suggestion docs/en/portfolio-app/setup.md` — 0/0/0.
- `pre-commit run --all-files` — all hooks green.
- YAML structure of `commons-settings.yml` matches the Probot
  Settings App schema (sibling `users`/`teams` lists empty, `apps`
  list with one entry).

## Risk / rollout notes

**Held as draft. Do not flip to ready until Phase 0 is verified.**

Pre-merge gate (operator-checked):

1. `nolte-portfolio-app` installed in `nolte/gh-plumbing` (and any
   other consumer whose `commons-settings.yml` extends this one).
2. `PORTFOLIO_APP_ID` variable and `PORTFOLIO_APP_PRIVATE_KEY` secret
   set at org or repo scope (Phase 0).
3. At least one `automerge` run confirmed showing the
   `Mint App installation token` step as `success` (not `skipped`)
   on the current head SHA — proof that the App token is being
   minted and the App can act.

Why those gates matter: without them, this PR would block direct
pushes from every actor on `develop` and `master` without granting
the App any ability to push instead. That would brick the very
release flow this bypass exists to unblock. The pre-conditions
prove the App is live before the bypass takes effect.

Cross-consumer impact: the `restrictions.apps` field propagates to
every consumer via `_extends:`. Personal-account consumers can't
honour it (Probot skips silently); organisation-owned consumers
adopt it on their next sync cycle. Consumers that don't want the
bypass can override the `branches` block in their per-repo
`.github/settings.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)