### PR TITLE
fix(workflows): wire refresh-master through the App-token pattern

### DIFF
--- a/.github/workflows/release-cd-refresh-master.yml
+++ b/.github/workflows/release-cd-refresh-master.yml
@@ -14,10 +14,26 @@ on:
         required: true
         type: string
 
+# This wrapper pushes a fast-forward merge to master through
+# `devmasx/merge-branch`. After Phase 2 of issue #330 lands its
+# push-restriction (`restrictions.apps: [nolte-portfolio-app]`) on
+# master, `GITHUB_TOKEN` no longer has the right to push to master —
+# the App token is now mandatory. Forwarding `vars.PORTFOLIO_APP_ID`
+# and `secrets.PORTFOLIO_APP_PRIVATE_KEY` into the reusable lets it
+# mint a short-lived installation token at job start.
+#
+# Backwards compatibility: when `vars.PORTFOLIO_APP_ID` is unset, the
+# reusable skips the mint step and falls through to `secrets.token`
+# (= GITHUB_TOKEN). On an organisation-owned consumer whose master is
+# also restricted via the inherited commons, the GITHUB_TOKEN push
+# would fail — the operator must complete Phase 0 first.
+
 jobs:
   refresh_presentation_branch:
     uses: nolte/gh-plumbing/.github/workflows/reusable-release-cd-refresh-master.yml@develop
     with:
       from_branch: ${{ inputs.tag || github.event.ref }}
+      app-id: ${{ vars.PORTFOLIO_APP_ID }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
+      app-private-key: ${{ secrets.PORTFOLIO_APP_PRIVATE_KEY }}

--- a/.github/workflows/reusable-release-cd-refresh-master.yml
+++ b/.github/workflows/reusable-release-cd-refresh-master.yml
@@ -11,15 +11,53 @@ on:
         required: false
         default: master
         type: string
+      app-id:
+        description: |
+          Numeric GitHub App ID of the portfolio App. When set, the
+          reusable mints a short-lived installation token from
+          `secrets.app-private-key` and uses it for the master fast-
+          forward. When empty (the default), the reusable falls
+          through to `secrets.token` — typically the consumer's
+          `GITHUB_TOKEN`. After Phase 2 of issue #330 lands its
+          push-restriction (`restrictions.apps: [<app-slug>]`) on
+          master, `GITHUB_TOKEN` no longer has the right to push to
+          master and the App token is mandatory.
+        required: false
+        type: string
+        default: ""
     secrets:
       token:
         required: true
+      app-private-key:
+        description: |
+          PEM-encoded private key for the App identified by `inputs.app-id`.
+          Required when `app-id` is set; ignored otherwise.
+        required: false
 
 jobs:
   refresh_presentation_branch:
     name: "Publish the the Release to Master"
     runs-on: ubuntu-latest
     steps:
+      # Mint an App installation token only when the caller has set
+      # inputs.app-id. The output token replaces secrets.token in the
+      # devmasx/merge-branch step via the
+      # `steps.app-token.outputs.token || secrets.token` fallback.
+      - name: Mint App installation token
+        id: app-token
+        if: ${{ inputs.app-id != '' }}
+        # Tolerate a half-configured setup. On any failure outputs.token
+        # is empty and the fallback to secrets.token kicks in — note
+        # that on a protected master with `restrictions.apps`, the
+        # fallback will fail at push time; the operator must complete
+        # Phase 0 (variable + secret) before this workflow can
+        # succeed on a fully-restricted master.
+        continue-on-error: true
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ inputs.app-id }}
+          private-key: ${{ secrets.app-private-key }}
+
       - name: Checkout master
         uses: actions/checkout@v6.0.0
       - name: Merge Tag -> Master
@@ -28,4 +66,4 @@ jobs:
           type: now
           from_branch: ${{ inputs.from_branch }}
           target_branch: ${{ inputs.target_branch }}
-          github_token: ${{ secrets.token }}
+          github_token: ${{ steps.app-token.outputs.token || secrets.token }}

--- a/docs/de/portfolio-app/setup.md
+++ b/docs/de/portfolio-app/setup.md
@@ -197,12 +197,16 @@ Schlüsseleigenschaften:
   begrenzt auf das aufrufende Repository. Es verlässt nie GitHubs
   Control Plane als langlebiges Credential.
 
-!!! note "Nur emittierende Wrapper brauchen das Pattern"
-    Wrapper, die Cascade-relevante Events emittieren, brauchen den
-    Mint-Pattern: `automerge.yaml`, `release-publish.yml`. Wrapper, die
-    nur Cascade-Events konsumieren (`release-drafter.yml`,
-    `release-cd-refresh-master.yml`, `release-cd-deliver-docs.yml`),
-    nutzen weiter `GITHUB_TOKEN`.
+!!! note "Drei Wrapper brauchen das App-Credential-Forwarding"
+    Wrapper, die durch einen geschützten Branch pushen, brauchen das
+    App-Token-Pattern: `automerge.yaml` (Squash-Merge nach `develop`),
+    `release-publish.yml` (Release-Flip — emittiert
+    `release: published` und kaskadiert weiter) und
+    `release-cd-refresh-master.yml` (Fast-Forward nach `master`, das
+    nach Phase 2 ebenfalls push-restricted ist). Wrapper, die nicht
+    direkt auf einen geschützten Branch pushen
+    (`release-drafter.yml`, `release-cd-deliver-docs.yml`), nutzen
+    weiter `GITHUB_TOKEN`.
 
 ---
 

--- a/docs/en/portfolio-app/setup.md
+++ b/docs/en/portfolio-app/setup.md
@@ -184,12 +184,20 @@ Key properties:
   generates a one-hour installation token, scoped to the calling
   repository. No long-lived credential leaves the GitHub control plane.
 
-!!! note "Only emitting wrappers need it"
-    Wrappers that emit cascade-relevant events need the App-credential
-    forwarding pattern: `automerge.yaml`, `release-publish.yml`.
-    Wrappers that only consume cascade events (`release-drafter.yml`,
-    `release-cd-refresh-master.yml`, `release-cd-deliver-docs.yml`)
-    keep using `GITHUB_TOKEN`.
+!!! note "Three wrappers need the App-credential forwarding"
+    Three wrappers push through a protected branch and need the
+    App-token pattern:
+
+    - `automerge.yaml` squash-merges to `develop`.
+    - `release-publish.yml` flips the release to published. The
+      resulting `release: published` event then cascades to other
+      workflows.
+    - `release-cd-refresh-master.yml` fast-forwards `master`. Master
+      is also push-restricted after phase 2.
+
+    Wrappers that don't push directly to a protected branch
+    (`release-drafter.yml`, `release-cd-deliver-docs.yml`) keep using
+    `GITHUB_TOKEN`.
 
 ---
 


### PR DESCRIPTION
## Summary

Gap surfaced while planning Phase 3 of #330. The Phase-2 PR (#355) added
\`restrictions.apps: [nolte-portfolio-app]\` to the \`master\` branch
protection in \`commons-settings.yml\`. With Probot Settings propagating
that to gh-plumbing's own \`master\`, the next \`release-cd-refresh-master\`
run would have failed: the wrapper still forwarded
\`secrets.GITHUB_TOKEN\`, and \`GITHUB_TOKEN\` is not in the
\`restrictions.apps\` list, so \`devmasx/merge-branch\`'s push to master
gets rejected.

This PR mirrors the Phase-1 pattern from #349 (App-token mint inside the
reusable, gated on \`inputs.app-id\`, fallback to \`secrets.token\`).

## Changes

- \`.github/workflows/reusable-release-cd-refresh-master.yml\`
  - New \`app-id\` input + \`app-private-key\` secret (both optional).
  - \`actions/create-github-app-token@v2\` mint step with
    \`continue-on-error: true\` and \`if: \${{ inputs.app-id != '' }}\`.
  - \`devmasx/merge-branch\` consumes
    \`\${{ steps.app-token.outputs.token || secrets.token }}\`.
- \`.github/workflows/release-cd-refresh-master.yml\` (consumer wrapper)
  - Forwards \`vars.PORTFOLIO_APP_ID\` and
    \`secrets.PORTFOLIO_APP_PRIVATE_KEY\` into the reusable.
  - Comment block explains why the App token is mandatory after Phase 2.
- \`docs/{en,de}/portfolio-app/setup.md\`
  - "Wrappers that need the App-credential forwarding" note now lists
    three wrappers: \`automerge.yaml\`, \`release-publish.yml\`,
    \`release-cd-refresh-master.yml\` — with \`refresh-master\` called out
    as a push-to-protected-branch case.

## Linked issues

Refs #330

## Testing

- \`mkdocs build --strict\` — both \`en\` and \`de\` trees build cleanly.
- \`vale --minAlertLevel=suggestion docs/en/portfolio-app/setup.md\` — 0/0/0.
- \`pre-commit run --all-files\` — all hooks green.
- Phase 0 already verified for \`nolte/gh-plumbing\`: org variable
  \`PORTFOLIO_APP_ID\` + org secret \`PORTFOLIO_APP_PRIVATE_KEY\` set,
  mint step succeeded on the recent automerge run (\`9479f5b5\` head SHA).
  The next \`release-cd-refresh-master\` invocation after this PR
  merges will mint the App token and push master through the bypass.

## Risk / rollout notes

Backwards-compatible: when \`vars.PORTFOLIO_APP_ID\` is unset, the
reusable skips the mint step and falls through to \`secrets.token\`
(= \`GITHUB_TOKEN\`). For consumers whose master isn't yet
push-restricted, behaviour is unchanged. For consumers whose master
IS restricted but Phase 0 isn't complete, the workflow now fails at
push time (no actor entitled to push) — that's a correct loud failure
of an unfinished setup, not a regression. The wrappers' inline
comment names this trade-off.

After this PR, the manual \`workflow_dispatch\` escape hatch from #329
becomes the documented notfall fallback, not the day-to-day path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)