### PR TITLE
feat(workflows): wire release-drafter and mkdocs through the App-token pattern (#357)

### DIFF
--- a/.github/workflows/release-cd-deliver-docs.yml
+++ b/.github/workflows/release-cd-deliver-docs.yml
@@ -2,8 +2,25 @@ on:
   release:
     types: [published]
 
+# When `vars.PORTFOLIO_APP_ID` is set, the reusable mints a short-lived
+# GitHub-App installation token from `secrets.PORTFOLIO_APP_PRIVATE_KEY`
+# and uses it for the gh-pages push. gh-pages has no branch protection,
+# so the App token here is a consistency / audit-trail improvement, not
+# a permissions requirement — but running the gh-pages push under the
+# same credential as the rest of the release toolchain keeps the
+# release audit trail homogeneous.
+# See spec/project/workflow-health/ §Known platform constraints (#357)
+# and docs/<lang>/portfolio-app/ for setup.
+#
+# Backwards compatibility: when `vars.PORTFOLIO_APP_ID` is unset, the
+# reusable falls through to `secrets.token` (= GITHUB_TOKEN). The
+# gh-pages push keeps working; only the audit-trail consistency is lost.
+
 jobs:
   publish_docs:
     uses: nolte/gh-plumbing/.github/workflows/reusable-mkdocs.yaml@develop
+    with:
+      app-id: ${{ vars.PORTFOLIO_APP_ID }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
+      app-private-key: ${{ secrets.PORTFOLIO_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,8 +4,24 @@ on:
     branches:
       - develop
 
+# When `vars.PORTFOLIO_APP_ID` is set, the reusable mints a short-lived
+# GitHub-App installation token from `secrets.PORTFOLIO_APP_PRIVATE_KEY`
+# and uses it for the release-drafter API calls. release-drafter is
+# itself a downstream of the automerge-driven `push: develop` cascade
+# closed by #330/#349; running it under the portfolio-App token keeps
+# the audit trail consistent across the full release toolchain.
+# See spec/project/workflow-health/ §Known platform constraints (#357)
+# and docs/<lang>/portfolio-app/ for setup.
+#
+# Backwards compatibility: when `vars.PORTFOLIO_APP_ID` is unset, the
+# reusable falls through to `secrets.token` (= GITHUB_TOKEN). release-
+# drafter keeps working; only the audit-trail consistency is lost.
+
 jobs:
   update_release_draft:
     uses: nolte/gh-plumbing/.github/workflows/reusable-release-drafter.yml@develop
+    with:
+      app-id: ${{ vars.PORTFOLIO_APP_ID }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
+      app-private-key: ${{ secrets.PORTFOLIO_APP_PRIVATE_KEY }}

--- a/.github/workflows/reusable-mkdocs.yaml
+++ b/.github/workflows/reusable-mkdocs.yaml
@@ -8,20 +8,56 @@ on:
         required: false
         default: "./requirements-dev.txt"
         type: string
+      app-id:
+        description: |
+          Numeric GitHub App ID of the portfolio App. When set, the
+          reusable mints a short-lived installation token from
+          `secrets.app-private-key` and uses it for the gh-pages push.
+          When empty (the default), the reusable falls through to
+          `secrets.token` — typically the consumer's `GITHUB_TOKEN`.
+          gh-pages is not branch-protected, so the App token here is a
+          consistency / audit-trail improvement, not a permissions
+          requirement (issue #357, spec/project/workflow-health/
+          §Known platform constraints).
+        required: false
+        type: string
+        default: ""
     secrets:
       token:
         required: true
+      app-private-key:
+        description: |
+          PEM-encoded private key for the App identified by `inputs.app-id`.
+          Required when `app-id` is set; ignored otherwise.
+        required: false
 
 jobs:
   publish_docs:
     name: "Publish the HTML Documentation"
     runs-on: ubuntu-latest
     steps:
+      # Mint an App installation token only when the caller has set
+      # inputs.app-id. The output token replaces secrets.token in the
+      # mhausenblas/mkdocs-deploy-gh-pages step via the
+      # steps.app-token.outputs.token || secrets.token fallback.
+      - name: Mint App installation token
+        id: app-token
+        if: ${{ inputs.app-id != '' }}
+        # Tolerate a half-configured setup. On any failure outputs.token
+        # is empty and the fallback to secrets.token kicks in — the
+        # gh-pages push keeps working, only the audit-trail consistency
+        # with the rest of the release toolchain is lost.
+        continue-on-error: true
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ inputs.app-id }}
+          private-key: ${{ secrets.app-private-key }}
+
       - name: Checkout master
         uses: actions/checkout@v6.0.0
 
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@1.26
         env:
-          GITHUB_TOKEN: ${{ secrets.token  }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.token }}
           REQUIREMENTS: ${{ inputs.requirements }}

--- a/.github/workflows/reusable-release-drafter.yml
+++ b/.github/workflows/reusable-release-drafter.yml
@@ -2,15 +2,53 @@ name: Release Drafter
 
 on:
   workflow_call:
+    inputs:
+      app-id:
+        description: |
+          Numeric GitHub App ID of the portfolio App. When set, the
+          reusable mints a short-lived installation token from
+          `secrets.app-private-key` and uses it for the release-edit
+          and gh CLI calls in this workflow. When empty (the default),
+          the reusable falls through to `secrets.token` — typically the
+          consumer's `GITHUB_TOKEN`. release-drafter is invoked after
+          an automerge-driven `push: develop`; running it under the
+          portfolio-App token keeps the audit trail consistent with the
+          rest of the release toolchain (issue #357,
+          spec/project/workflow-health/ §Known platform constraints).
+        required: false
+        type: string
+        default: ""
     secrets:
       token:
         required: true
+      app-private-key:
+        description: |
+          PEM-encoded private key for the App identified by `inputs.app-id`.
+          Required when `app-id` is set; ignored otherwise.
+        required: false
 
 jobs:
   update_release_draft:
     name: Update Release Draft
     runs-on: ubuntu-latest
     steps:
+      # Mint an App installation token only when the caller has set
+      # inputs.app-id. The output token (when present) replaces
+      # secrets.token everywhere downstream in this job via the
+      # steps.app-token.outputs.token || secrets.token fallback.
+      - name: Mint App installation token
+        id: app-token
+        if: ${{ inputs.app-id != '' }}
+        # Tolerate a half-configured setup. On any failure outputs.token
+        # is empty and the fallback to secrets.token kicks in — release-
+        # drafter keeps working under GITHUB_TOKEN, only the audit-trail
+        # consistency is lost.
+        continue-on-error: true
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ inputs.app-id }}
+          private-key: ${{ secrets.app-private-key }}
+
       # Capture the release-skill-layer project-context block from the current
       # open draft, if any, before release-drafter regenerates the body.
       # release-drafter@v6 fully rewrites the body from its template, so any
@@ -20,7 +58,7 @@ jobs:
       - name: Capture project-context block
         id: capture
         env:
-          GH_TOKEN: ${{ secrets.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.token }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -70,12 +108,12 @@ jobs:
       - name: Update Release Draft
         uses: release-drafter/release-drafter@v6
         env:
-          GITHUB_TOKEN: ${{ secrets.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.token }}
 
       - name: Restore project-context block
         if: steps.capture.outputs.had_markers == 'true'
         env:
-          GH_TOKEN: ${{ secrets.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.token }}
           REPO: ${{ github.repository }}
           CAPTURED_TAG: ${{ steps.capture.outputs.captured_tag }}
         run: |

--- a/docs/de/portfolio-app/setup.md
+++ b/docs/de/portfolio-app/setup.md
@@ -148,10 +148,11 @@ Jedes aktivierte Häkchen würde nur tote Webhook-Versuche erzeugen.
 
 ## Wrapper-Pattern (für nachgelagerte Konsumenten)
 
-Die beiden Cascade-emittierenden Wrapper in `nolte/gh-plumbing` zeigen
-das Pattern. Übernimm dieselbe Form in dein Repository für jeden
-Wrapper, der eine `reusable-*.yaml` aufruft, deren Arbeit nachgelagerte
-Workflows triggern soll.
+Die Cascade-emittierenden Wrapper in `nolte/gh-plumbing` zeigen das
+Pattern. Übernimm dieselbe Form in dein Repository für jeden Wrapper,
+der eine `reusable-*.yaml` aufruft, deren Arbeit nachgelagerte
+Workflows triggern soll oder die du unter derselben Release-Audit-
+Identität halten willst.
 
 ```yaml title=".github/workflows/automerge.yaml"
 on:
@@ -164,49 +165,55 @@ on:
   status: {}
 
 jobs:
-  mint-token:
-    runs-on: ubuntu-latest
-    outputs:
-      token: ${{ steps.app-token.outputs.token || github.token }}
-    steps:
-      - id: app-token
-        if: ${{ vars.PORTFOLIO_APP_ID != '' }}
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ vars.PORTFOLIO_APP_ID }}
-          private-key: ${{ secrets.PORTFOLIO_APP_PRIVATE_KEY }}
-
   automerge:
-    needs: mint-token
     uses: nolte/gh-plumbing/.github/workflows/reusable-automerge.yaml@develop
+    with:
+      app-id: ${{ vars.PORTFOLIO_APP_ID }}
     secrets:
-      token: ${{ needs.mint-token.outputs.token }}
+      token: ${{ secrets.GITHUB_TOKEN }}
+      app-private-key: ${{ secrets.PORTFOLIO_APP_PRIVATE_KEY }}
 ```
 
 Schlüsseleigenschaften:
 
 - **Backwards-kompatibel.** Wenn `vars.PORTFOLIO_APP_ID` ungesetzt ist,
-  überspringt der Mint-Step und der Wrapper fällt zurück auf
-  `github.token` (= `GITHUB_TOKEN`). Das Verhalten für nicht-adoptierte
-  Konsumenten ist identisch zum Pre-App-Zustand.
-- **Reusables bleiben tokentyp-agnostisch.** Die Reusables in
-  `nolte/gh-plumbing` akzeptieren jede Token-Form; nur der Wrapper
-  entscheidet, ob die App zum Zug kommt.
+  überspringt der Reusable den Mint-Step und fällt zurück auf
+  `secrets.token` (= `GITHUB_TOKEN`). Das Verhalten für
+  nicht-adoptierte Konsumenten ist identisch zum Pre-App-Zustand.
+- **Mint passiert im Reusable.** GitHub Actions maskiert
+  App-Token-Outputs und blockiert sie an Job-Grenzen — ein separater
+  Mint-Job im Wrapper kann das Token nicht an einen nachgelagerten
+  Reusable-Call weitergeben. Der Reusable hält den Mint-Step selbst,
+  gated auf `inputs.app-id`.
 - **Kurze Token-Lebensdauer.**
   `actions/create-github-app-token@v2` erzeugt ein 1-Stunden-Installation-Token,
   begrenzt auf das aufrufende Repository. Es verlässt nie GitHubs
   Control Plane als langlebiges Credential.
 
-!!! note "Drei Wrapper brauchen das App-Credential-Forwarding"
-    Wrapper, die durch einen geschützten Branch pushen, brauchen das
-    App-Token-Pattern: `automerge.yaml` (Squash-Merge nach `develop`),
-    `release-publish.yml` (Release-Flip — emittiert
-    `release: published` und kaskadiert weiter) und
-    `release-cd-refresh-master.yml` (Fast-Forward nach `master`, das
-    nach Phase 2 ebenfalls push-restricted ist). Wrapper, die nicht
-    direkt auf einen geschützten Branch pushen
-    (`release-drafter.yml`, `release-cd-deliver-docs.yml`), nutzen
-    weiter `GITHUB_TOKEN`.
+!!! note "Fünf Wrapper brauchen das App-Credential-Forwarding"
+    Drei Wrapper pushen durch einen geschützten Branch und **müssen**
+    das App-Token-Pattern verwenden:
+
+    - `automerge.yaml` (Squash-Merge nach `develop`).
+    - `release-publish.yml` (Release-Flip — emittiert
+      `release: published` und kaskadiert weiter).
+    - `release-cd-refresh-master.yml` (Fast-Forward nach `master`, das
+      nach Phase 2 ebenfalls push-restricted ist).
+
+    Zwei weitere Wrapper reichen dasselbe Credential aus
+    Konsistenz- und Audit-Trail-Gründen durch, obwohl ihr Ziel-Branch
+    nicht geschützt ist:
+
+    - `release-drafter.yml` aktualisiert den Release-Entwurf über die
+      GitHub-API. Unter dem Portfolio-App-Token läuft jeder
+      Release-Toolchain-Schritt unter einer einheitlichen Identität.
+    - `release-cd-deliver-docs.yml` pusht die gerenderte Site nach
+      `gh-pages`. `gh-pages` hat keine Protection — das App-Token ist
+      hier rein Audit-Trail-Verbesserung.
+
+    Alle fünf Wrapper bleiben backwards-kompatibel: ist
+    `vars.PORTFOLIO_APP_ID` ungesetzt, fällt jeder Reusable auf
+    `GITHUB_TOKEN` zurück und funktioniert weiter.
 
 ---
 

--- a/docs/en/portfolio-app/setup.md
+++ b/docs/en/portfolio-app/setup.md
@@ -144,10 +144,11 @@ subscription on would only generate dead webhook attempts.
 
 ## Wrapper pattern (for downstream consumers)
 
-The two cascade-emitting wrappers in `nolte/gh-plumbing` show the
+The cascade-emitting wrappers in `nolte/gh-plumbing` show the
 pattern. Copy the same shape into your repository for any wrapper
 calling a `reusable-*.yaml` whose work should trigger downstream
-workflows.
+workflows or that you want to keep under the same release-audit
+identity.
 
 ```yaml title=".github/workflows/automerge.yaml"
 on:
@@ -184,8 +185,8 @@ Key properties:
   generates a one-hour installation token, scoped to the calling
   repository. No long-lived credential leaves the GitHub control plane.
 
-!!! note "Three wrappers need the App-credential forwarding"
-    Three wrappers push through a protected branch and need the
+!!! note "Five wrappers need the App-credential forwarding"
+    Three wrappers push through a protected branch and **need** the
     App-token pattern:
 
     - `automerge.yaml` squash-merges to `develop`.
@@ -195,9 +196,20 @@ Key properties:
     - `release-cd-refresh-master.yml` fast-forwards `master`. Master
       is also push-restricted after phase 2.
 
-    Wrappers that don't push directly to a protected branch
-    (`release-drafter.yml`, `release-cd-deliver-docs.yml`) keep using
-    `GITHUB_TOKEN`.
+    Two more wrappers forward the same credential for consistency and
+    audit-trail homogeneity, even though their target branch isn't
+    protected:
+
+    - `release-drafter.yml` updates the draft release through the
+      GitHub API. Running it under the portfolio-App token keeps every
+      release-toolchain step under one identity.
+    - `release-cd-deliver-docs.yml` pushes the rendered site to
+      `gh-pages`. `gh-pages` has no protection, so the App token here
+      is an audit-trail improvement only.
+
+    All five wrappers stay backwards-compatible: when
+    `vars.PORTFOLIO_APP_ID` is unset, each reusable falls through to
+    `GITHUB_TOKEN` and keeps working.
 
 ---
 


### PR DESCRIPTION
## Summary

- Extend the portfolio-App credential plumbing introduced in #349/#356 to the last two reusables on the release cascade: `reusable-release-drafter.yml` and `reusable-mkdocs.yaml`.
- Update their local wrappers (`release-drafter.yml`, `release-cd-deliver-docs.yml`) to forward `vars.PORTFOLIO_APP_ID` + `secrets.PORTFOLIO_APP_PRIVATE_KEY`.
- Bring `docs/{en,de}/portfolio-app/setup.md` in line: the "three wrappers need the App credential" notice now covers all five wrappers, with the split between MUST (branch-protected push) and SHOULD (consistency / audit-trail). Drive-by: replace the stale cross-job mint-token code sample in the German doc with the inside-reusable pattern the EN doc and the real wrappers already use.

## Changes

- `.github/workflows/reusable-release-drafter.yml`: add `inputs.app-id` + `secrets.app-private-key`, prepend the mint step, route the three `GH_TOKEN` / `GITHUB_TOKEN` env vars through `steps.app-token.outputs.token || secrets.token`.
- `.github/workflows/reusable-mkdocs.yaml`: same shape; routes the `mhausenblas/mkdocs-deploy-gh-pages` action's `GITHUB_TOKEN` env through the same fallback. Mint step is `continue-on-error: true` so a half-configured caller falls back to `GITHUB_TOKEN` instead of breaking the deploy.
- `.github/workflows/release-drafter.yml`, `release-cd-deliver-docs.yml`: wire the new input + secret through, with the same comment block style used by `automerge.yaml`, `release-publish.yml`, and `release-cd-refresh-master.yml`.
- `docs/{en,de}/portfolio-app/setup.md`: rewrite the wrapper-coverage notice; align the German code sample with the EN doc (it had drifted to a cross-job mint pattern that the reusables no longer support).

## Linked issues

- Closes #357 on the gh-plumbing side. The issue's last acceptance criterion (consumer-side end-to-end cascade test in `nolte/taskfiles`) requires adoption there and is tracked separately.
- Follow-on to #330 (portfolio App provisioning), #349 (Phase 1 mint in emitting wrappers), #355 (branch-protection bypass actor), #356 (refresh-master wiring).

## Testing

- [x] `pre-commit run --all-files` — passes (`check-yaml`, EOF/whitespace, label-description-length).
- [x] YAML schema cross-check via `yaml.safe_load`: `inputs` / `secrets` on the two updated reusables match the golden-template shape from `reusable-automerge.yaml` / `reusable-release-publish.yml` (`inputs={app-id, …}`, `secrets={token, app-private-key}`).
- [x] Token-reference grep: every `secrets.token` / `GITHUB_TOKEN` consumer in the two updated reusables now reads via `steps.app-token.outputs.token || secrets.token`; no path was missed.
- [ ] Consumer-side end-to-end test (`nolte/taskfiles` release cycle without manual `gh workflow run` interventions) — out of scope for this PR, requires release-cycle window in the consumer.

## Risk / rollout notes

- **Backwards-compatible by design.** Each new `inputs.app-id` defaults to `""`, and the mint step is gated on `inputs.app-id != ''` with `continue-on-error: true`. Consumers that haven't adopted the App see no behaviour change.
- **No spec change.** The pattern is unchanged from the one ratified in #349/#356 (`spec/project/workflow-health/` §Known platform constraints, `spec/project/release-automation/` §Authentication). Only the set of wrappers it covers grows from 3 to 5.
- **Audit-trail-only for two of them.** `release-drafter.yml` writes to the draft release via GitHub API and `release-cd-deliver-docs.yml` pushes to unprotected `gh-pages`. Neither needs the App for permissions; both ride it to keep release-cycle audit logs homogeneous.
- **Consumer migration.** Consumers that already declare `vars.PORTFOLIO_APP_ID` + `secrets.PORTFOLIO_APP_PRIVATE_KEY` (per the Phase 1 / #330 rollout) get the new behaviour automatically once they bump their `@develop` (or next tag) pin. Consumers that haven't adopted continue to run under `GITHUB_TOKEN`.