### PR TITLE
docs(portfolio-app): document Issues:write permission for auto-close

### DIFF
--- a/docs/de/portfolio-app/setup.md
+++ b/docs/de/portfolio-app/setup.md
@@ -59,17 +59,17 @@ vergeben:
 |---|---|---|
 | `Contents` | `Read and write` | Squash-Merge nach develop, Releases editieren, master fast-forwarden |
 | `Pull requests` | `Read and write` | `pascalgn/automerge-action` liest und merged PRs |
+| `Issues` | `Read and write` | Auto-Close von Issues, die im PR-Body via `Closes #N` / `Fixes #N` / `Resolves #N` referenziert sind, wenn die App den Squash-Merge ausführt. GitHub schließt referenzierte Issues nur, wenn der mergende Actor `Issues: write` hat — fehlt diese Permission, parst GitHub die Autolinks zwar in `closingIssuesReferences`, aber der Close-Flip feuert nicht (Live-Beobachtung an #357 / #358). |
 | `Actions` | `Read-only` | `release-publish` liest `gh run list` für den Post-Publish-Cascade-Check |
 | `Metadata` | `Read-only` | Pflicht-Basis (setzt GitHub automatisch und lässt sich nicht abwählen) |
 
 **Jede andere Repository-Permission** bleibt auf `No access`,
-insbesondere die drei, die verwandt klingen, aber keine sind:
+insbesondere die zwei, die verwandt klingen, aber keine sind:
 
 | Permission | Setting | Wieso NICHT |
 |---|---|---|
 | `Administration` | `No access` | Die Probot Settings App verwaltet Repo-Konfiguration. Diese Permission hier zu setzen erhöht nur die Angriffsfläche, ohne Nutzen. |
 | `Workflows` | `No access` | Würde der App erlauben, `.github/workflows/*.yaml` zu überschreiben. Unsere Use-Case merged Branches und Releases, keine Workflow-Dateien. Später aktivieren, falls jemals nötig. |
-| `Issues` | `No access` | Die App liest und schreibt keine Issues. |
 
 **Alle Organization permissions** und **alle Account permissions**
 bleiben auf `No access` — die Arbeit der App ist repo-scoped.
@@ -226,6 +226,12 @@ selbst triggern:
 |---|---|
 | `automerge`-Label an einen grünen PR | `automerge.yaml` squash-merged → `release-drafter.yml` aktualisiert den Entwurf → `build-static-tests.yaml` läuft auf dem neuen develop-Tip |
 | `release-publish.yml` für offenen Entwurf dispatchen | `reusable-release-publish.yml` flippt draft=false → `release-cd-refresh-master.yml` fast-forwarded master → `release-cd-deliver-docs.yml` baut die MkDocs-Site neu |
+
+Eine dritte Self-Check-Zeile betrifft den Issue-Lifecycle:
+
+| Aktion | Erwartetes Ergebnis |
+|---|---|
+| PR squash-mergen, dessen Body `Closes #N` enthält | Issue `#N` flippt automatisch auf `CLOSED`; `gh issue view N --json state` liefert `CLOSED`. Setzt die App-Permission `Issues: Read and write` voraus — ohne sie greift der Merge zwar, der Close feuert aber nicht, obwohl `gh pr view --json closingIssuesReferences` den Autolink korrekt geparst zeigt. |
 
 Wenn ein Cascade immer noch nicht triggert, prüfe:
 

--- a/docs/en/portfolio-app/setup.md
+++ b/docs/en/portfolio-app/setup.md
@@ -58,17 +58,17 @@ permissions**:
 |---|---|---|
 | `Contents` | `Read and write` | Squash-merge to develop, edit releases, fast-forward master |
 | `Pull requests` | `Read and write` | `pascalgn/automerge-action` reads and merges PRs |
+| `Issues` | `Read and write` | Auto-close issues referenced via `Closes #N` / `Fixes #N` / `Resolves #N` in the PR body when the App squash-merges. GitHub only honours these autolinks when the merging actor has `Issues: write`; without this scope the autolinks parse correctly into `closingIssuesReferences` but the close never fires (observed end-to-end on #357 / #358). |
 | `Actions` | `Read-only` | `release-publish` reads `gh run list` for the post-publish cascade sanity check |
 | `Metadata` | `Read-only` | Mandatory baseline (GitHub sets this automatically and won't let you disable it) |
 
 Leave **every other Repository permission** on `No access`, in
-particular the three that look related but aren't:
+particular the two that look related but aren't:
 
 | Permission | Setting | Reason to skip |
 |---|---|---|
 | `Administration` | `No access` | The Probot Settings App owns repository configuration. Granting this here adds attack surface for no gain. |
 | `Workflows` | `No access` | Would let the App rewrite `.github/workflows/*.yaml`. The use case in this repository merges branches and releases, not workflow files. Add later only if a future reusable needs it. |
-| `Issues` | `No access` | The App neither reads nor writes issues. |
 
 Leave **all Organization permissions** and **all Account permissions**
 on `No access`. The App's work is repository-scoped.
@@ -221,6 +221,12 @@ After provisioning and adoption, both cascade chains should self-trigger:
 |---|---|
 | Apply `automerge` label to a green PR | `automerge.yaml` squash-merges → `release-drafter.yml` updates the draft → `build-static-tests.yaml` runs on the new develop tip |
 | Dispatch `release-publish.yml` for an open draft | `reusable-release-publish.yml` flips draft=false → `release-cd-refresh-master.yml` fast-forwards master → `release-cd-deliver-docs.yml` rebuilds the mkdocs site |
+
+A third self-check covers the issue lifecycle:
+
+| Action | Expected outcome |
+|---|---|
+| Squash-merge a PR whose body says `Closes #N` | Issue `#N` flips to `CLOSED` automatically; `gh issue view N --json state` returns `CLOSED`. Requires the App's `Issues: Read and write` permission — without it the merge succeeds but the close never fires, even though `gh pr view --json closingIssuesReferences` shows the link was parsed. |
 
 If a cascade still fails to fire, check:
 

--- a/terraform/portfolio-app/README.md
+++ b/terraform/portfolio-app/README.md
@@ -67,7 +67,15 @@ the configuration sets both or neither.
 Before `terraform apply`:
 
 1. The portfolio App carries the permissions listed in
-   `docs/en/portfolio-app/setup.md` §Permissions the app requires.
+   `docs/en/portfolio-app/setup.md` §Permissions the app requires —
+   `Contents: Read and write`, `Pull requests: Read and write`,
+   `Issues: Read and write`, `Actions: Read-only`, plus the implicit
+   `Metadata: Read-only` baseline. `Issues: Read and write` is what
+   lets an App-driven squash-merge auto-close issues referenced via
+   `Closes #N` in the PR body; without it the merge succeeds but the
+   issue stays `OPEN`. The Terraform module doesn't manage App
+   permissions — they're set on the App's registration page in the
+   GitHub UI.
 2. The App lives in every repository you intend to list under
    `consumer_repositories`.
 3. The Terraform provider holds credentials for the owner account


### PR DESCRIPTION
## Summary

- Add `Issues: Read and write` to the portfolio App's required permissions in `docs/{en,de}/portfolio-app/setup.md`, with the reason captured inline (auto-close via `Closes #N` after an App-driven squash-merge).
- Add a third self-check row to the §Verification section in both languages so a future maintainer can confirm the close fires end-to-end after adopting the permission.
- Expand the `terraform/portfolio-app/README.md` pre-conditions list to spell out the five permissions explicitly; note that the Terraform module doesn't manage App permissions.

## Changes

- `docs/en/portfolio-app/setup.md`: move `Issues` from the skip-table to the required-permissions table; new verification row; "two" instead of "three" skip entries.
- `docs/de/portfolio-app/setup.md`: symmetric DE update.
- `terraform/portfolio-app/README.md`: extend the §Pre-conditions item that today points at the docs to include the explicit five-permission list and the `Issues: write` rationale.

## Linked issues

- Follow-up to the live observation made while merging #358 (which closed #357 manually because the App-driven merge didn't auto-close it). Resolution path: grant the App the missing permission and update the docs so future readers know to do so.
- Cross-references: #330 (portfolio App provisioning), #349 / #356 / #358 (App-token rollout to the cascade reusables).

## Testing

- [x] `pre-commit run --all-files` passes (`check-yaml`, EOF/whitespace, label-description-length).
- [x] Diff is documentation only — no workflow or code changes; static-tests still run as a sanity check.
- [ ] End-to-end auto-close verification — requires the operator to (a) widen the App's permission to `Issues: Read and write` on the registration page, (b) re-approve the installation in every consumer repository so GitHub picks up the new scope, then (c) merge the next App-driven PR with a `Closes #N` body and confirm `gh issue view N --json state` returns `CLOSED`. Out of scope for this PR.

## Risk / rollout notes

- **Docs-only.** No behavioural change in workflows. The docs claim becomes operationally true only after the operator widens the App's permission in the GitHub UI and the consumers re-approve. Until then, the existing manual `gh issue close` workaround (captured in the memory note) stays the routine.
- **Permission widening is operator action, not Terraform.** GitHub Apps have no API surface to manage permission scope from code; the Terraform module covers organisation variable + secret + branch-protection bypass only. The README update makes this boundary explicit.
- **Consumer re-approval flow.** When an App's permissions widen, GitHub flips every existing installation into "Awaiting approval"; the consumer-repo owner has to click through once. Mentioned implicitly via "set on the App's registration page" but worth flagging at adoption time.