### PR TITLE
feat(portfolio): add portfolio manifest (reusable CI/CD plumbing capabilities)

### DIFF
--- a/project/portfolio.yml
+++ b/project/portfolio.yml
@@ -1,0 +1,45 @@
+# Portfolio manifest for nolte/gh-plumbing.
+# Schema: spec/portfolio/portfolio-management/ §Capability inventory per repository
+# Audience references resolve against AUDIENCES.md at the repo root.
+
+capabilities:
+  - name: reusable-github-actions-workflows
+    description: >-
+      A library of reusable GitHub Actions workflows (reusable-*.yaml:
+      pre-commit, mkdocs deploy, spelling/Vale, automerge,
+      release-drafter/publish, Docker lint/build/publish, Ansible
+      molecule/galaxy, Terraform lint, Trivy, chain-bench, dependency-review)
+      that downstream nolte/* repositories call to get consistent CI/CD without
+      reimplementing pipelines.
+    audience:
+      - Downstream repositories consuming reusable workflows
+      - Repository maintainer (nolte)
+    status: active
+    rationale: >-
+      gh-plumbing is the single portfolio source of reusable CI/CD workflows;
+      consolidating them here removes the per-repo pipeline duplication the
+      2026-06-02 portfolio audit flagged (W2 copy-paste smell).
+  - name: probot-commons-config
+    description: >-
+      Shared Probot app configuration commons (settings, release-drafter,
+      boring-cyborg, stale presets) that downstream nolte/* repositories extend
+      so repository governance stays uniform across the portfolio.
+    audience:
+      - Downstream repositories extending Probot configurations
+      - Repository maintainer (nolte)
+    status: active
+    rationale: >-
+      Centralising the Probot commons here lets every consumer inherit one
+      governance baseline via extends rather than maintaining per-repo settings.
+  - name: renovate-shared-presets
+    description: >-
+      Shared Renovate configuration presets (renovate-configs/) that downstream
+      nolte/* repositories extend for consistent dependency-update grouping,
+      scheduling, and labelling.
+    audience:
+      - Downstream repositories consuming Renovate presets
+      - Renovate bot
+    status: active
+    rationale: >-
+      One curated Renovate preset source keeps dependency-bot behaviour
+      consistent across the portfolio.


### PR DESCRIPTION
## Summary

Adds the first `project/portfolio.yml` to `nolte/gh-plumbing`, resolving Warning **W2** (and part of **W3**) from the 2026-06-02 portfolio audit (nolte/claude-shared `.audits/portfolio/2026-06-02.md`, tracked in nolte/claude-shared#262). gh-plumbing provided a portfolio-wide reusable-CI/CD capability consumed by ≥3 members but declared no manifest, so the capability was unattributed in the inventory.

## Changes

Declares three capabilities, each grounded in what the repo ships and mapped to existing `AUDIENCES.md` entries:

- **reusable-github-actions-workflows** — the `reusable-*.yaml` workflow library downstream nolte/* repos call (audience: downstream workflow consumers, maintainer).
- **probot-commons-config** — the shared Probot settings/release-drafter/boring-cyborg/stale commons downstream repos `extends` (audience: downstream Probot-config extenders, maintainer).
- **renovate-shared-presets** — the `renovate-configs/` presets downstream repos extend (audience: downstream Renovate-preset consumers, Renovate bot).

All `status: active`. The `terraform/` tree is intentionally not declared (boundary versus `terraform-github-bootstrap` unclear; no capability invented).

## Linked issues

Refs nolte/claude-shared#262

## Testing

- `project/portfolio.yml` validated locally: 3 capabilities, all five required fields present (`name`, `description`, `audience`, `status`, `rationale`); folded-scalar descriptions reconstruct verbatim.

## Risk / rollout notes

Low — additive manifest metadata; no code or workflow change. A follow-up `mission-define` is still needed for the render to quote a mission (gh-plumbing has no `project/mission.md` yet); tracked under claude-shared#262.