### PR TITLE
feat(renovate): track nolte/vale-style releases via .vale.ini customManager

### DIFF
--- a/renovate-configs/common.json
+++ b/renovate-configs/common.json
@@ -4,5 +4,14 @@
     ":dependencyDashboard",
     ":enablePreCommit"
   ],
-  "labels": ["chore","dependencies"]
+  "labels": ["chore","dependencies"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)\\.vale\\.ini$/"],
+      "matchStrings": ["nolte/vale-style/releases/download/(?<currentValue>v[0-9.]+)/"],
+      "depNameTemplate": "nolte/vale-style",
+      "datasourceTemplate": "github-releases"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Adds a regex `customManager` to the shared `renovate-configs/common.json` so Renovate tracks the `nolte/vale-style` release pinned by URL in a repo's `.vale.ini` and proposes pin bumps automatically.

## Why

Repos pin the Vale style package by release URL:

```ini
Packages = https://github.com/nolte/vale-style/releases/download/v0.1.3/nolte-styles.zip
```

Nothing in the shared config (`config:base`, dependency dashboard, pre-commit) nor in consumer `renovate.json5` files covers that URL, so the pin never gets bumped. Concretely, `nolte/workstation` sat on `v0.1.3` while the latest release was `v0.1.14` — 11 releases of vocabulary behind, which is what let `chezmoi`/`nolte` trip `Vale.Spelling` there.

## Changes

- `renovate-configs/common.json`: add a `customManagers` entry (regex) that
  - matches any `.vale.ini`,
  - captures the `v<x.y.z>` tag from the `nolte/vale-style/releases/download/<tag>/` URL as `currentValue`,
  - resolves it against the `github-releases` datasource for `nolte/vale-style`.

## Risk / rollout notes

- **No-op for repos without a matching `.vale.ini`** — the manager only activates where the URL pattern is present, so it is safe to roll out portfolio-wide via the existing `_extends` references.
- Pure config addition; existing `extends` / `labels` behaviour is unchanged.
- After this lands and a new `gh-plumbing` release tag is cut, consumers that pin `renovate-configs/common#<tag>` pick it up on their next ref bump.

## Related

- nolte/vale-style#19 — adds `[Cc]hezmoi` upstream (the term that surfaced this gap).
- nolte/workstation#84 — the Lektorat PR where the stale-pin symptom appeared.