### PR TITLE
fix(docs): bump pymdown-extensions to 10.21.3 for Pygments 2.20 compat

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,4 @@ mkdocs-material==9.7.0
 mkdocs-static-i18n==1.3.1
 mkdocs==1.6.1
 pre-commit==4.5.0
-pymdown-extensions==10.17.1
+pymdown-extensions==10.21.3


### PR DESCRIPTION
## Summary

Fix the `release-cd-deliver-docs.yml` MkDocs build, which has failed on every release since **v1.1.19**. The deploy action installs `requirements-dev.txt`, where `pygments` is unpinned and resolves to 2.20.0; `pymdown-extensions` 10.17.1 passes `filename=None` to the Pygments `HtmlFormatter` for code blocks without a `title=`, and Pygments 2.20.0 calls `html.escape()` on it, raising `AttributeError: 'NoneType' object has no attribute 'replace'`.

## Changes

- Bump `pymdown-extensions` from `10.17.1` to `10.21.3` in `requirements-dev.txt`, which restores correct `filename` handling and is compatible with Pygments 2.20.0.

## Linked issues

None

## Testing

- Reproduced the failure locally in a fresh venv from `requirements-dev.txt` (Pygments 2.20.0): `mkdocs build --strict` raised the exact `NoneType … replace` error while rendering `docs/en/workflows/release.md`.
- Applied the bump in a fresh venv: `mkdocs build --strict` exits `0` (EN + DE i18n trees build clean) with Pygments still at 2.20.0.
- `pre-commit run --files requirements-dev.txt` passes.

## Risk / rollout notes

Low risk — a single dev-dependency bump that only affects the docs build. No reusable-workflow contract changes. The next published release will run the green deliver-docs path.

Originating source: `release-cd-deliver-docs.yml` failure on the v1.1.22 publish ([run 27493734569](https://github.com/nolte/gh-plumbing/actions/runs/27493734569)) — broken since v1.1.19, surfaced during `release-publish-trigger`.
Dispatched specialist: no matching specialist existed — generalist handled