### PR TITLE
docs: render icons, surface language switcher, document coverage workflows

### DIFF
--- a/docs/de/workflows/coverage.md
+++ b/docs/de/workflows/coverage.md
@@ -1,0 +1,59 @@
+# Coverage
+
+Führt die Tests eines Projekts aus und stellt den Coverage-Bericht in der Job-Zusammenfassung von GitHub Actions dar, sodass Konsumenten die Testabdeckung ohne externen Dienst sehen. Zwei Varianten decken die gängigen Ökosysteme ab.
+
+- [`reusable-python-coverage.yaml`](#python) — pytest mit pytest-cov
+- [`reusable-nodejs-coverage.yaml`](#nodejs) — Vitest oder Jest über den Istanbul-`json-summary`-Bericht
+
+Beide rendern eine Markdown-Tabelle in `$GITHUB_STEP_SUMMARY` — auch wenn die Tests fehlschlagen — und bieten ein optionales `fail-under`-Gate.
+
+---
+
+## Python
+
+```yaml title=".github/workflows/coverage.yaml"
+jobs:
+  coverage:
+    uses: nolte/gh-plumbing/.github/workflows/reusable-python-coverage.yaml@develop
+    with:
+      coverage-source: my_package
+      fail-under: 80
+```
+
+!!! tip "Voraussetzungen"
+    Das `install-command` (Standard `pip install -e .[test]`) muss `pytest` und `pytest-cov` mitbringen. Die Coverage wird über `coverage report --format=markdown` gerendert, was Coverage.py ≥ 7.0 voraussetzt (im aktuellen `pytest-cov` enthalten).
+
+---
+
+## Node.js
+
+```yaml title=".github/workflows/coverage.yaml"
+jobs:
+  coverage:
+    uses: nolte/gh-plumbing/.github/workflows/reusable-nodejs-coverage.yaml@develop
+    with:
+      fail-under: 80
+```
+
+!!! tip "json-summary-Bericht"
+    Das `test-command` (Standard `npm test`) muss einen Istanbul-`json-summary`-Bericht nach `coverage-summary-path` (Standard `coverage/coverage-summary.json`) schreiben. Sowohl Vitest (`--coverage.reporter=json-summary`) als auch Jest (`--coverageReporters=json-summary`) erzeugen dieses Format.
+
+---
+
+## Zentrale Konfiguration
+
+=== "Python-Coverage-Workflow"
+
+    ```yaml
+    {%
+       include "../../../.github/workflows/reusable-python-coverage.yaml"
+    %}
+    ```
+
+=== "Node.js-Coverage-Workflow"
+
+    ```yaml
+    {%
+       include "../../../.github/workflows/reusable-nodejs-coverage.yaml"
+    %}
+    ```

--- a/docs/de/workflows/index.md
+++ b/docs/de/workflows/index.md
@@ -30,6 +30,14 @@ uses: nolte/gh-plumbing/.github/workflows/reusable-<name>.yaml@develop
 
     [:octicons-arrow-right-24: reusable-pre-commit](static-tests.md)
 
+-   :material-chart-box-outline: **Coverage**
+
+    ---
+
+    Python- oder Node.js-Testabdeckung in die Job-Zusammenfassung rendern, mit optionalem `fail-under`-Gate.
+
+    [:octicons-arrow-right-24: Coverage-Workflows](coverage.md)
+
 -   :material-book-open-variant: **Dokumentation**
 
     ---

--- a/docs/en/workflows/coverage.md
+++ b/docs/en/workflows/coverage.md
@@ -1,0 +1,59 @@
+# Coverage
+
+Runs a project's tests and surfaces the coverage report in the GitHub Actions job summary, so consumers see coverage without an external service. Two variants cover the common ecosystems.
+
+- [`reusable-python-coverage.yaml`](#python) — pytest with pytest-cov
+- [`reusable-nodejs-coverage.yaml`](#nodejs) — Vitest or Jest via the Istanbul `json-summary` report
+
+Both render a Markdown table into `$GITHUB_STEP_SUMMARY`—even when the tests fail—and expose an optional `fail-under` gate.
+
+---
+
+## Python
+
+```yaml title=".github/workflows/coverage.yaml"
+jobs:
+  coverage:
+    uses: nolte/gh-plumbing/.github/workflows/reusable-python-coverage.yaml@develop
+    with:
+      coverage-source: my_package
+      fail-under: 80
+```
+
+!!! tip "Requirements"
+    The `install-command` (default `pip install -e .[test]`) must pull in `pytest` and `pytest-cov`. Coverage is rendered via `coverage report --format=markdown`, which needs Coverage.py ≥ 7.0 (shipped with current `pytest-cov`).
+
+---
+
+## Node.js
+
+```yaml title=".github/workflows/coverage.yaml"
+jobs:
+  coverage:
+    uses: nolte/gh-plumbing/.github/workflows/reusable-nodejs-coverage.yaml@develop
+    with:
+      fail-under: 80
+```
+
+!!! tip "json-summary report"
+    The `test-command` (default `npm test`) must write an Istanbul `json-summary` report to `coverage-summary-path` (default `coverage/coverage-summary.json`). Both Vitest (`--coverage.reporter=json-summary`) and Jest (`--coverageReporters=json-summary`) emit this format.
+
+---
+
+## Central configuration
+
+=== "Python coverage workflow"
+
+    ```yaml
+    {%
+       include "../../../.github/workflows/reusable-python-coverage.yaml"
+    %}
+    ```
+
+=== "Node.js coverage workflow"
+
+    ```yaml
+    {%
+       include "../../../.github/workflows/reusable-nodejs-coverage.yaml"
+    %}
+    ```

--- a/docs/en/workflows/index.md
+++ b/docs/en/workflows/index.md
@@ -30,6 +30,14 @@ uses: nolte/gh-plumbing/.github/workflows/reusable-<name>.yaml@develop
 
     [:octicons-arrow-right-24: reusable-pre-commit](static-tests.md)
 
+-   :material-chart-box-outline: **Coverage**
+
+    ---
+
+    Render Python or Node.js test coverage into the job summary, with an optional `fail-under` gate.
+
+    [:octicons-arrow-right-24: Coverage workflows](coverage.md)
+
 -   :material-book-open-variant: **Documentation**
 
     ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,20 @@ theme:
 extra_css:
   - stylesheets/extra.css
 
+# Header language switcher. The i18n plugin emits the SEO `hreflang`
+# alternates automatically, but Material only renders the visible
+# selector when `extra.alternate` is declared. Links carry the
+# `/gh-plumbing/` site base (see site_url); `en` is the default locale
+# and builds to the site root, `de` builds under `/de/`.
+extra:
+  alternate:
+    - name: English
+      link: /gh-plumbing/
+      lang: en
+    - name: Deutsch
+      link: /gh-plumbing/de/
+      lang: de
+
 plugins:
   - search
   - include-markdown
@@ -86,6 +100,9 @@ markdown_extensions:
       permalink: true
   - pymdownx.caret
   - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span
@@ -117,6 +134,7 @@ nav:
   - Workflows:
       - workflows/index.md
       - Static tests: workflows/static-tests.md
+      - Coverage: workflows/coverage.md
       - Documentation: workflows/documentation.md
       - Release: workflows/release.md
   - Probot:


### PR DESCRIPTION
## Summary

Overhaul the MkDocs docs: fix the broken grid-card icons, make the EN/DE language switcher visible in the header, and document the two new coverage workflows. The docs were already bilingual (full EN/DE parity) — the switcher was just never rendered and the icons never resolved.

## Changes

- **Icons:** add the `pymdownx.emoji` markdown extension (twemoji → SVG). The `:material-*:` / `:octicons-*:` icons in every grid card and button rendered as literal `:material-...:` text before because the extension was missing.
- **Language switcher:** add `extra.alternate` (English → `/gh-plumbing/`, Deutsch → `/gh-plumbing/de/`). The `i18n` plugin already emitted the SEO `hreflang` alternates, but Material only renders the clickable header selector when `extra.alternate` is declared.
- **Coverage docs:** add a Coverage detail page (`docs/en/workflows/coverage.md` + `docs/de/workflows/coverage.md`) documenting `reusable-python-coverage` and `reusable-nodejs-coverage`, a card on the Workflows index (EN + DE), and a nav entry.

## Linked issues

None

## Testing

- `mkdocs build --strict` is green (EN + DE trees build clean).
- Verified in the generated HTML: literal `:material-` occurrences dropped from 5 → 0 and twemoji SVGs render; the header switcher offers `English` + `Deutsch` (`md-select__link` × 2) on both EN and DE pages; both coverage pages build and the index card links to them.
- `pre-commit run` passes on all changed files (incl. `check yaml` on `mkdocs.yml`).

## Risk / rollout notes

Low risk — docs-only (`mkdocs.yml` + `docs/`). No reusable-workflow contracts touched. The `pymdownx.emoji` extension and `extra.alternate` are standard Material configuration. This rides on the pymdown-extensions 10.21.3 bump from #365, so the next docs deploy is also expected to be green.