### PR TITLE
chore(ci): wire mkdocs --strict build into static CI

### DIFF
--- a/.github/workflows/build-static-tests.yaml
+++ b/.github/workflows/build-static-tests.yaml
@@ -5,6 +5,8 @@ on:
 jobs:
   static:
     uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@develop
+  docs:
+    uses: nolte/gh-plumbing/.github/workflows/reusable-mkdocs-build.yaml@develop
   security:
     uses: nolte/gh-plumbing/.github/workflows/reusable-trivy.yaml@develop
   chain-bench:


### PR DESCRIPTION
## Summary

Follow-up to #367: wire the now-landed `reusable-mkdocs-build.yaml` into the per-push static CI as a `docs` job. The `uses: …@develop` self-reference resolves cleanly now that the reusable workflow exists on `develop`. This makes `mkdocs build --strict` run on every push, closing the gap that let the Pygments 2.20 render bug ship across v1.1.19–v1.1.22 (only `release-cd-deliver-docs` ran the build before, at release time).

## Changes

- Add a `docs` job to `.github/workflows/build-static-tests.yaml` calling `reusable-mkdocs-build.yaml@develop` (check context `docs / MkDocs Build`).

## Linked issues

None

## Testing

- `reusable-mkdocs-build.yaml` is on `develop` (merged in #367), so the self-reference resolves — unlike the first attempt in #367 where the unresolved `@develop` reference failed workflow validation.
- `mkdocs build --strict` was verified green on the current `develop` state in #367.
- YAML parses; `pre-commit run` passes.

## Risk / rollout notes

Low risk — adds one CI job. The new `docs / MkDocs Build` check runs on every push and is visible on PRs. It is **not yet merge-blocking**: to make it required, add `docs / MkDocs Build` to the required status checks on `develop` via the GitHub branch-protection UI (same mechanism as the existing `static / Static CI Tests` required check; the local `.github/settings.yml` does not declare check contexts).

Originating source: release-cd-deliver-docs.yml failures v1.1.19-v1.1.22 surfaced during release-publish-trigger; follow-up to #365 (render-bug fix) and #367 (reusable workflow).
Dispatched specialist: no matching specialist existed - generalist handled