### PR TITLE
chore(settings): require docs / MkDocs Build check on develop

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -7,11 +7,17 @@
 # file as well (a comment touch is enough) so the App re-runs the merge.
 # Tracked by https://github.com/nolte/gh-plumbing/issues/331.
 #
-# Last propagation: 2026-05-20 — Phase 2 of #330: declare
+# Last propagation: 2026-06-14 — declare this repo's own required status
+# checks on develop. commons-settings.yml leaves develop's
+# `required_status_checks.contexts` empty by portfolio policy ("Consumers
+# MUST declare their own required-check contexts in their per-repo
+# .github/settings.yml"); the branches block below supplies them. Per the
+# Probot Settings App `_extends` merge rules, branch entries merge by
+# `name`, so declaring only `develop` here keeps the `master` block and
+# develop's `enforce_admins` / `restrictions` from commons untouched.
+# (Previous propagation 2026-05-20 — Phase 2 of #330: declare
 # nolte-portfolio-app as branch-protection bypass actor on develop and
-# master (push_restrictions actor) so the workflow-driven primary path
-# of spec/project/release-automation/ §Version-bearing file alignment
-# becomes usable.
+# master.)
 
 _extends: gh-plumbing:.github/commons-settings.yml
 
@@ -20,3 +26,17 @@ repository:
   description: Github Project plumbing
   homepage: https://nolte.github.io/gh-plumbing/
   topics: github, plumbing
+
+branches:
+  # Merges by `name` into the commons `develop` block; only
+  # required_status_checks.contexts is overridden here. The check
+  # contexts are "<caller-job-id> / <reusable-job-display-name>":
+  # `static` job → reusable-pre-commit's "Static CI Tests";
+  # `docs` job → reusable-mkdocs-build's "MkDocs Build".
+  - name: develop
+    protection:
+      required_status_checks:
+        strict: true
+        contexts:
+          - static / Static CI Tests
+          - docs / MkDocs Build


### PR DESCRIPTION
## Summary

Make the `docs / MkDocs Build` check (wired into static CI in #368) merge-blocking on `develop`, instead of only visible. This declares gh-plumbing's own required status checks in its per-repo `settings.yml` — which `commons-settings.yml` explicitly mandates ("Consumers MUST declare their own required-check contexts in their per-repo .github/settings.yml"; the commons develop block leaves `contexts: []` by portfolio policy).

## Changes

- Add a `branches:` block to `.github/settings.yml` declaring `develop`'s `required_status_checks.contexts` as `static / Static CI Tests` + `docs / MkDocs Build`.
- Update the propagation-note header comment.

## Linked issues

None

## Testing

- YAML parses; `pre-commit run` passes.
- Verified via the Probot Settings App docs (`repository-settings/app` `configuration.md`) that `branches` entries merge **by `name`**, so declaring only `develop` here leaves the commons `master` block and develop's `enforce_admins` / `restrictions` untouched — no risk of clobbering the App-bypass restriction added in #355.
- Check-context names confirmed against live runs: `static / Static CI Tests` (existing required) and `docs / MkDocs Build` (green on #368).

## Risk / rollout notes

Low-to-medium risk — touches branch protection. The merge pushes `settings.yml`, which re-triggers the Probot Settings App sync (commons changes alone don't trigger it). **Post-merge verification required:** confirm `gh api repos/nolte/gh-plumbing/branches/develop/protection/required_status_checks` lists both contexts. If the App did not apply the contexts (the live state previously diverged from commons, suggesting the sync may not push this field), fall back to setting `docs / MkDocs Build` as required in the branch-protection UI. The merge-by-name semantics guarantee that, worst case, nothing is lost — `enforce_admins` and the App-bypass restriction stay intact either way.

Originating source: follow-up to #367/#368 (mkdocs --strict gate); makes the gate enforceable per the goal stated during release-publish-trigger triage.
Dispatched specialist: no matching specialist existed - generalist handled