### PR TITLE
chore(ci): give every workflow a speaking display name

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -1,3 +1,5 @@
+name: Automerge
+
 on:
   pull_request:
     types:

--- a/.github/workflows/build-static-tests.yaml
+++ b/.github/workflows/build-static-tests.yaml
@@ -1,3 +1,5 @@
+name: Static CI Tests
+
 on:
   push:
   workflow_dispatch:

--- a/.github/workflows/release-cd-deliver-docs.yml
+++ b/.github/workflows/release-cd-deliver-docs.yml
@@ -1,3 +1,5 @@
+name: Release — Deliver Docs
+
 on:
   release:
     types: [published]

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,3 +1,5 @@
+name: Release Drafter
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,3 +1,5 @@
+name: Release Publish
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/reusable-ansible-molecule.yaml
+++ b/.github/workflows/reusable-ansible-molecule.yaml
@@ -1,4 +1,4 @@
-name: Release Deliver Docs
+name: Reusable — Ansible Molecule
 
 on:
   workflow_call:

--- a/.github/workflows/reusable-automerge.yaml
+++ b/.github/workflows/reusable-automerge.yaml
@@ -1,4 +1,4 @@
-name: automerge
+name: Reusable — Automerge
 
 on:
   workflow_call:

--- a/.github/workflows/reusable-mkdocs.yaml
+++ b/.github/workflows/reusable-mkdocs.yaml
@@ -1,4 +1,4 @@
-name: Release Deliver Docs
+name: Reusable — MkDocs Deploy
 
 on:
   workflow_call:

--- a/.github/workflows/reusable-pre-commit.yaml
+++ b/.github/workflows/reusable-pre-commit.yaml
@@ -1,4 +1,4 @@
-name: CI Static Tests
+name: Reusable — Pre-Commit
 
 on:
   workflow_call:

--- a/.github/workflows/reusable-sphinx.yaml
+++ b/.github/workflows/reusable-sphinx.yaml
@@ -1,4 +1,4 @@
-name: Release Deliver Docs
+name: Reusable — Sphinx Deploy
 
 on:
   workflow_call:

--- a/.github/workflows/reusable-tf-lint.yaml
+++ b/.github/workflows/reusable-tf-lint.yaml
@@ -1,4 +1,4 @@
-name: tf-lint
+name: Reusable — Terraform Lint
 
 on:
   workflow_call:

--- a/.github/workflows/reusable-trivy.yaml
+++ b/.github/workflows/reusable-trivy.yaml
@@ -1,4 +1,4 @@
-name: Security Tests
+name: Reusable — Trivy Security Scan
 
 on:
   workflow_call:

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,3 +1,5 @@
+name: Stale
+
 on:
   schedule:
   - cron: "0 0 * * *"


### PR DESCRIPTION
## Summary

Several workflows rendered their **file path** in the Actions sidebar instead of a name, because they lacked a top-level `name:` key. This gives every workflow a speaking, unique display name.

## Changes

- Add a top-level `name:` to the six caller workflows that had none: `automerge` → *Automerge*, `build-static-tests` → *Static CI Tests*, `release-cd-deliver-docs` → *Release — Deliver Docs*, `release-drafter` → *Release Drafter*, `release-publish` → *Release Publish*, `stale` → *Stale*.
- Fix three reusable workflows that all carried the wrong/duplicate name **"Release Deliver Docs"**: `reusable-ansible-molecule` (mislabelled) → *Reusable — Ansible Molecule*, `reusable-mkdocs` → *Reusable — MkDocs Deploy*, `reusable-sphinx` → *Reusable — Sphinx Deploy*.
- Unify four off-scheme reusables onto the `Reusable — …` prefix: `automerge`, `tf-lint`, `trivy` (*Security Tests*), `pre-commit` (*CI Static Tests*).

## Linked issues

_None._

## Testing

- Only top-level `name:` keys changed; **job names are untouched**, so required status-check contexts (e.g. `static / …`) are unaffected.
- Verified no remaining duplicate names except the legitimate caller↔reusable pairs (Dependency Review, Release Drafter, Release Publish, Release Deliver to Master, Spelling Check).

## Risk / rollout notes

Cosmetic. The top-level `name:` of a reusable workflow does not appear in the status-check context when called via `uses:`, so branch protection is not affected. Downstream consumer repos with copied caller workflows (e.g. `kamerplanter`) need the same change separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)