### PR TITLE
feat(mkdocs): add pre-build-command hook to deploy + strict-build reusables

### DIFF
--- a/.github/workflows/reusable-mkdocs-build.yaml
+++ b/.github/workflows/reusable-mkdocs-build.yaml
@@ -15,6 +15,18 @@ on:
         required: false
         type: string
         default: "requirements-dev.txt"
+      pre-build-command:
+        description: |
+          Optional shell command run after the toolchain install and
+          before `mkdocs build`. Use it to generate derived pages (for
+          example a skill/agent catalog) that are gitignored and
+          therefore absent from a fresh checkout, so the strict build
+          does not fail on missing nav targets. The requirements file
+          is already installed, so a Python generator can import its
+          deps directly. Empty (default) skips the step.
+        required: false
+        type: string
+        default: ""
 
 jobs:
   build:
@@ -32,6 +44,10 @@ jobs:
 
       - name: Install MkDocs toolchain
         run: pip install -r ${{ inputs.requirements }}
+
+      - name: Pre-build command
+        if: ${{ inputs.pre-build-command != '' }}
+        run: ${{ inputs.pre-build-command }}
 
       # --strict turns broken links, missing nav entries, and plugin
       # render errors into a non-zero exit, so docs regressions surface

--- a/.github/workflows/reusable-mkdocs.yaml
+++ b/.github/workflows/reusable-mkdocs.yaml
@@ -8,6 +8,26 @@ on:
         required: false
         default: "./requirements-dev.txt"
         type: string
+      pre-build-command:
+        description: |
+          Optional shell command run on the runner after checkout and
+          before the gh-pages build/deploy. Use it to generate derived
+          pages (for example a skill/agent catalog) that are gitignored
+          and therefore absent from a fresh checkout. The requirements
+          file is installed on the runner first, so a Python generator
+          can import its deps directly; the generated files live in the
+          workspace and are picked up by the deploy step. Empty
+          (default) skips the step.
+        required: false
+        type: string
+        default: ""
+      python-version:
+        description: |
+          Python version for the pre-build command step. Only used when
+          pre-build-command is set.
+        required: false
+        type: string
+        default: "3.x"
       app-id:
         description: |
           Numeric GitHub App ID of the portfolio App. When set, the
@@ -55,6 +75,22 @@ jobs:
 
       - name: Checkout master
         uses: actions/checkout@v6.0.0
+
+      # Optional pre-build hook. Runs on the runner host before the
+      # Dockerised deploy action; files it writes into the workspace
+      # (e.g. a generated catalog under docs/) are mounted into and
+      # picked up by mkdocs gh-deploy.
+      - name: Set up Python for pre-build
+        if: ${{ inputs.pre-build-command != '' }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Pre-build command
+        if: ${{ inputs.pre-build-command != '' }}
+        run: |
+          pip install -r ${{ inputs.requirements }}
+          ${{ inputs.pre-build-command }}
 
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@1.26


### PR DESCRIPTION
## Summary

Both MkDocs reusables build from a fresh checkout, so docs pages that are generated and gitignored (e.g. a skill/agent catalog produced by a consumer-side script) are absent at build time. The nav then links to non-existent pages — 404s on the deployed site, and a failing `mkdocs build --strict` check. Add an optional `pre-build-command` hook so consumers can regenerate those pages before the build.

## Changes

- `reusable-mkdocs.yaml` (deploy): new `pre-build-command` + `python-version` inputs. When the command is set, the reusable sets up Python, installs `requirements` on the runner host, then runs the command before the Dockerised `mkdocs gh-deploy` (which picks up the workspace files).
- `reusable-mkdocs-build.yaml` (strict build): new `pre-build-command` input. Runs after the toolchain install, before `mkdocs build --strict`.
- Empty default → existing callers unaffected.

## Linked issues

None

## Testing

- `yaml.safe_load` parses both workflows.
- Behavioral validation happens at the first consumer adoption (kamerplanter docs deploy, which generates a gitignored skill/agent catalog via `scripts/docs/gen_catalog.py`).

## Risk / rollout notes

Low. Additive, opt-in inputs with empty defaults; no change for current callers. Consuming repos must bump to the release that includes this and pass `pre-build-command`. Needs a version tag cut after merge.