### PR TITLE
docs(hacs): fix Vale prose errors in HACS workflow docs

### DIFF
--- a/docs/de/workflows/index.md
+++ b/docs/de/workflows/index.md
@@ -58,7 +58,7 @@ uses: nolte/gh-plumbing/.github/workflows/reusable-<name>.yaml@develop
 
     ---
 
-    Eine HACS-Custom-Integration mit `hacs/action` und hassfest validieren und das Release-ZIP-Asset ausliefern.
+    Eine HACS-Custom-Integration mit `hacs/action` und `hassfest` validieren und das Release-ZIP-Asset ausliefern.
 
     [:octicons-arrow-right-24: HACS-Validierung](hacs.md)
 

--- a/docs/en/workflows/hacs.md
+++ b/docs/en/workflows/hacs.md
@@ -20,7 +20,7 @@ jobs:
 ```
 
 !!! tip "Custom repository vs. default store"
-    Leave `ignore` empty for a default-store-grade run — HACS forbids ignored checks for default-store inclusion. A pure custom repository may ignore checks it cannot satisfy, e.g. `with: { ignore: "brands" }`.
+    Leave `ignore` empty for a default-store-grade run. HACS forbids ignored checks for default-store inclusion. A pure custom repository may ignore checks it can't satisfy, for example `with: { ignore: "brands" }`.
 
 ---
 

--- a/docs/en/workflows/index.md
+++ b/docs/en/workflows/index.md
@@ -58,7 +58,7 @@ uses: nolte/gh-plumbing/.github/workflows/reusable-<name>.yaml@develop
 
     ---
 
-    Validate a HACS custom integration with `hacs/action` and hassfest, and ship the release ZIP asset.
+    Validate a HACS custom integration with `hacs/action` and `hassfest`, and ship the release ZIP asset.
 
     [:octicons-arrow-right-24: HACS validation](hacs.md)
 


### PR DESCRIPTION
## Summary

Follow-up to #373. The HACS docs page merged with three Vale (Microsoft) prose errors because `spelling / vale` is a non-blocking check and automerge landed #373 before the fix push could be picked up. This brings the fix into `develop`.

## Changes

- `docs/en/workflows/hacs.md`: tip block — drop spaces around the em-dash, `cannot` → `can't`, `e.g.` → `for example`
- `docs/{en,de}/workflows/index.md`: wrap the tool name `hassfest` in code so Vale's spell check skips it (matches the detail page)

## Linked issues

Follow-up to #373.

## Testing

`vale --minAlertLevel=error` over the changed files: 0 errors.

## Risk / rollout notes

Docs-only prose change; no workflow behavior affected.