### PR TITLE
fix(release): pin gate 4 alignment-commit check to TARGET_SHA

### DIFF
--- a/.github/workflows/reusable-release-publish.yml
+++ b/.github/workflows/reusable-release-publish.yml
@@ -266,12 +266,12 @@ jobs:
           print(f"All {len(vbf['entries'])} version-bearing file(s) aligned to {tag}.")
 
           paths = [e["path"] for e in vbf["entries"]]
-          log_args = ["git", "log", "-1", "--pretty=%s", "origin/develop", "--"] + paths
+          log_args = ["git", "log", "-1", "--pretty=%s", sha, "--"] + paths
           subject = subprocess.run(log_args, capture_output=True, text=True, check=True).stdout.strip()
 
           expected_prefix = f"chore(release): {tag}"
           if not subject.startswith(expected_prefix):
-              print(f"::error::No 'chore(release): {tag}' alignment commit on origin/develop touching the version-bearing files.")
+              print(f"::error::No 'chore(release): {tag}' alignment commit at {sha[:8]} touching the version-bearing files.")
               print(f"::error::Most recent commit subject on these paths: '{subject}'")
               print(f"::error::Per spec/project/release-automation/ §Pre-publish verification, the alignment commit subject must start with '{expected_prefix}'.")
               sys.exit(1)


### PR DESCRIPTION
## Summary

Pin gate 4 (the alignment-commit subject check) in
`reusable-release-publish.yml` to the resolved `TARGET_SHA`, the same commit
gate 3 directly above already inspects. Today gate 4 read `origin/develop`'s
tip, so a draft targeting any commit other than the develop tip would have its
version-content validated at one commit and its `chore(release): <tag>`
subject validated at a different one.

## Changes

- Replace the hard-coded `origin/develop` ref in gate 4's `git log` with the
  already-bound local `sha` variable (= `TARGET_SHA`).
- Reword gate 4's "no alignment commit" error to name the inspected short SHA
  (`at {sha[:8]}`) instead of "on origin/develop", consistent with gate 3's
  diagnostics.

## Linked issues

Closes #376

## Testing

- `python3 -c "import yaml; yaml.safe_load(open(...))"` — workflow YAML parses.
- Extracted the embedded Python heredoc and ran `python3 -m py_compile` — OK.
- `pre-commit run --files .github/workflows/reusable-release-publish.yml` — all hooks pass.

## Risk / rollout notes

Low. Public-API change: every downstream repo consuming
`reusable-release-publish.yml@develop` picks it up immediately. Behaviour is
unchanged for the common case (draft target == develop tip), where the two
SHAs coincide; the fix only matters when a draft targets an off-tip commit.