### PR TITLE
feat(release): implement workflow-driven version-bearing auto-bump (primary path)

### DIFF
--- a/.github/workflows/reusable-release-publish.yml
+++ b/.github/workflows/reusable-release-publish.yml
@@ -336,8 +336,12 @@ jobs:
                       continue
                   for c, k in targets:
                       c[k] = target_value(c[k], tag)
-                  m = re.search(r"\n( +)\S", raw)
-                  indent = len(m.group(1)) if m else 2
+                  # Preserve the file's exact indent unit (spaces or tabs):
+                  # json.dumps accepts a string indent and uses it verbatim, so a
+                  # tab-indented manifest stays tab-indented instead of silently
+                  # collapsing to 2 spaces. Default to 2 spaces when undetectable.
+                  m = re.search(r"\n([ \t]+)\S", raw)
+                  indent = m.group(1) if m else 2
                   open(path, "w").write(json.dumps(data, indent=indent, ensure_ascii=False) + "\n")
               elif fmt == "toml":
                   # tomllib is read-only; rewrite the single `<key> = "<value>"`

--- a/.github/workflows/reusable-release-publish.yml
+++ b/.github/workflows/reusable-release-publish.yml
@@ -46,6 +46,29 @@ on:
         required: false
         type: string
         default: ""
+      auto-align:
+        description: |
+          Opt-in to the spec's "Primary path: Workflow-driven"
+          (spec/project/release-automation/ §Version-bearing file
+          alignment). When true AND an App installation token is
+          available (inputs.app-id set + secrets.app-private-key valid),
+          the reusable updates every version-bearing file to the target
+          tag under its transform, commits `chore(release): <tag>` on
+          develop authored by the App, pushes, and realigns the draft's
+          target_commitish to the new SHA. When false (the default) — or
+          when no App token is present — the reusable only verifies
+          alignment and leaves the `chore(release): <tag>` commit to the
+          operator fallback path. The opt-in plus the App-token presence
+          together enforce the spec's "MUST NOT be enabled until the
+          portfolio App/PAT is installed and `.github/settings.yml`
+          explicitly names the credential as a bypass actor": no token or
+          no opt-in ⇒ no write ⇒ fallback. A push rejected by develop's
+          branch protection degrades gracefully — the step warns and the
+          Verify step below produces the operator-fallback message rather
+          than wedging the release.
+        required: false
+        type: boolean
+        default: false
     secrets:
       token:
         required: true
@@ -168,8 +191,21 @@ jobs:
 
           if pathlib.Path(".claude-plugin/plugin.json").exists():
               entries = [{"path": ".claude-plugin/plugin.json", "selector": "version", "transform": "strip-leading-v", "format": "json"}]
-              if pathlib.Path(".claude-plugin/marketplace.json").exists():
+              mp = pathlib.Path(".claude-plugin/marketplace.json")
+              if mp.exists():
                   entries.append({"path": ".claude-plugin/marketplace.json", "selector": "metadata.version", "transform": "strip-leading-v", "format": "json"})
+                  # Per spec/project/release-automation/ §Version-bearing files the
+                  # marketplace.json selector is `$.metadata.version` AND `$.plugins[].version`.
+                  # Guard on existence: only emit the array selector when EVERY plugins[]
+                  # entry actually declares a version key, so single-plugin repos and repos
+                  # whose plugins[] omit version (the claude-shared workaround) don't start
+                  # failing verification on a key the wildcard read would not find.
+                  try:
+                      plugins = (json.loads(mp.read_text()) or {}).get("plugins", [])
+                  except (ValueError, OSError):
+                      plugins = []
+                  if isinstance(plugins, list) and plugins and all(isinstance(p, dict) and "version" in p for p in plugins):
+                      entries.append({"path": ".claude-plugin/marketplace.json", "selector": "plugins[].version", "transform": "strip-leading-v", "format": "json"})
               json.dump({"source": "claude-plugin", "entries": entries}, sys.stdout)
               sys.exit(0)
 
@@ -207,15 +243,178 @@ jobs:
           echo "Detected project type: $source ($count version-bearing file(s))"
           jq . vbf.json
 
+      # Shared version-bearing selector grammar, written once and imported by
+      # BOTH the align (write) and verify (read) steps so the dot-path + array-
+      # wildcard grammar can never drift between them. Grammar: dot-separated
+      # parts; a part may carry a trailing `[]` or `[*]` meaning "every element
+      # of this array" (spec/project/release-automation/ §Version-bearing files
+      # lists `$.plugins[].version`). refs(data, selector) returns (container,
+      # key) leaf refs — read via container[key], written via container[key]=v.
+      - name: Prepare selector helper
+        if: steps.vbf.outputs.count != '0'
+        run: |
+          set -euo pipefail
+          cat > selectorlib.py <<'PY'
+          def refs(data, selector):
+              """Return [(container, key), ...] scalar-leaf refs for a dot-path
+              selector with optional `[]`/`[*]` array wildcards. Raises
+              KeyError/TypeError/IndexError on a path that does not resolve."""
+              parts = [p for p in selector.split(".") if p]
+              nodes = [data]
+              for i, raw in enumerate(parts):
+                  if raw.endswith("[]"):
+                      key, wild = raw[:-2], True
+                  elif raw.endswith("[*]"):
+                      key, wild = raw[:-3], True
+                  else:
+                      key, wild = raw, False
+                  last = i == len(parts) - 1
+                  nxt = []
+                  for n in nodes:
+                      child = n[key]
+                      if wild:
+                          if not isinstance(child, list):
+                              raise TypeError(f"selector part '{raw}' is not an array")
+                          if last:
+                              nxt.extend((child, idx) for idx in range(len(child)))
+                          else:
+                              nxt.extend(child)
+                      else:
+                          nxt.append((n, key) if last else child)
+                  nodes = nxt
+              return nodes
+          PY
+
+      # Primary path (spec/project/release-automation/ §Version-bearing file
+      # alignment → "Primary path: Workflow-driven"). Runs only when the caller
+      # opts in (inputs.auto-align) AND a bypass App token is available
+      # (steps.app-token.outputs.token != ''): the workflow then aligns every
+      # version-bearing file to the target tag, commits `chore(release): <tag>`
+      # on develop authored by the App, and pushes — automating the last manual
+      # link end-to-end. The opt-in plus the App-token presence together enforce
+      # the spec's enablement gate ("MUST NOT be enabled until the App is
+      # installed and named as a bypass actor"): no opt-in or no token ⇒ this
+      # step is skipped and the Verify step's operator-fallback message governs
+      # (the fallback path stays byte-for-byte unchanged).
+      - name: Align version-bearing files (primary path)
+        id: align
+        if: ${{ inputs.auto-align && steps.app-token.outputs.token != '' && steps.vbf.outputs.count != '0' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.token }}
+          TAG: ${{ inputs.tag }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+          # Edit every version-bearing file in the checked-out develop tree to the
+          # target tag, honouring each file's existing v-prefix convention and
+          # every selector match (incl. array wildcards). Format-preserving:
+          # JSON via an indent-detecting round-trip, TOML via a targeted regex on
+          # the version line — minimal diffs, no whole-file reformat, no tomlkit.
+          python3 - <<'PY'
+          import json, os, re, sys
+          from selectorlib import refs
+
+          tag = os.environ["TAG"]
+
+          with open("vbf.json") as f:
+              vbf = json.load(f)
+
+          def target_value(existing, tag):
+              # strip-leading-v: keep the file's existing convention — write the
+              # v-prefixed tag only when the current value already uses a v
+              # (spec SHOULD: the workflow MUST NOT silently rewrite the convention).
+              return tag if str(existing).startswith("v") else tag.lstrip("v")
+
+          for e in vbf["entries"]:
+              path, selector, fmt = e["path"], e["selector"], e["format"]
+              raw = open(path).read()
+              if fmt == "json":
+                  data = json.loads(raw)
+                  targets = refs(data, selector)
+                  if not targets:
+                      continue
+                  for c, k in targets:
+                      c[k] = target_value(c[k], tag)
+                  m = re.search(r"\n( +)\S", raw)
+                  indent = len(m.group(1)) if m else 2
+                  open(path, "w").write(json.dumps(data, indent=indent, ensure_ascii=False) + "\n")
+              elif fmt == "toml":
+                  # tomllib is read-only; rewrite the single `<key> = "<value>"`
+                  # line in place with a targeted regex (no tomlkit dependency).
+                  import tomllib
+                  data = tomllib.loads(raw)
+                  for c, k in refs(data, selector):
+                      existing = str(c[k])
+                      newval = target_value(existing, tag)
+                      pat = re.compile(r'^(\s*' + re.escape(k) + r'\s*=\s*)"' + re.escape(existing) + r'"', re.M)
+                      raw, n = pat.subn(lambda mo: mo.group(1) + '"' + newval + '"', raw, count=1)
+                      if n == 0:
+                          print(f"::error::Could not rewrite {k} in {path} (format-preserving regex matched nothing).", file=sys.stderr)
+                          sys.exit(1)
+                  open(path, "w").write(raw)
+              else:
+                  print(f"::error::Unsupported format '{fmt}' for {path}", file=sys.stderr)
+                  sys.exit(1)
+          PY
+
+          mapfile -t paths < <(jq -r '.entries[].path' vbf.json | sort -u)
+
+          if git diff --quiet -- "${paths[@]}"; then
+            # Already aligned at develop HEAD (a prior primary run or a merged
+            # fallback `chore(release)` PR). No commit needed; the draft target is
+            # realigned to develop HEAD below so Verify reads the aligned tree.
+            committed=false
+            new_sha=$(git rev-parse HEAD)
+            echo "Version-bearing files already aligned at $new_sha; no commit needed."
+          else
+            committed=true
+            slug="${APP_SLUG:-github-actions}"
+            uid=$(gh api "/users/${slug}[bot]" --jq .id 2>/dev/null || echo "")
+            git config user.name "${slug}[bot]"
+            if [[ -n "$uid" ]]; then
+              git config user.email "${uid}+${slug}[bot]@users.noreply.github.com"
+            else
+              git config user.email "${slug}[bot]@users.noreply.github.com"
+            fi
+            git add -- "${paths[@]}"
+            git commit -m "chore(release): $TAG"
+            new_sha=$(git rev-parse HEAD)
+            echo "Committed chore(release): $TAG at $new_sha."
+          fi
+
+          echo "target_sha=$new_sha" >> "$GITHUB_OUTPUT"
+
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "::notice::Dry run — aligned locally at ${new_sha:0:8}; not pushing to develop or realigning the draft."
+            { echo; echo "### Alignment (dry run)"; echo; echo "- Would commit/push \`chore(release): $TAG\` and realign the draft to \`${new_sha:0:8}\`."; } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Push the alignment commit (if any) and realign the draft target to the
+          # aligned SHA so the published tag is cut from exactly this commit. The
+          # push authority is the App being a declared bypass actor on develop
+          # (branch-protection config, not a workflow `permissions:` key); per
+          # spec the push respects `enforce_admins: true` — the bypass is declared,
+          # not stolen. A rejected push degrades to the operator fallback path.
+          if [[ "$committed" == "true" ]]; then
+            git push origin HEAD:develop
+            echo "::notice::Pushed alignment commit to develop."
+          fi
+          gh release edit "$TAG" --target "$new_sha"
+          echo "::notice::Realigned draft '$TAG' target to ${new_sha:0:8}."
+          { echo; echo "### Alignment"; echo; echo "- Aligned version-bearing files and set draft '$TAG' target to \`${new_sha:0:8}\`."; } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Verify version-bearing-file alignment
         if: steps.vbf.outputs.count != '0'
         env:
           TAG: ${{ inputs.tag }}
-          TARGET_SHA: ${{ steps.draft.outputs.target_sha }}
+          TARGET_SHA: ${{ steps.align.outputs.target_sha || steps.draft.outputs.target_sha }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
           import json, os, subprocess, sys
+          from selectorlib import refs
 
           tag = os.environ["TAG"]
           sha = os.environ["TARGET_SHA"]
@@ -223,21 +422,17 @@ jobs:
           with open("vbf.json") as f:
               vbf = json.load(f)
 
-          def value_at_sha(path, sha, fmt, selector):
+          def data_at_sha(path, sha, fmt):
               raw = subprocess.run(
                   ["git", "show", f"{sha}:{path}"],
                   capture_output=True, text=True, check=True,
               ).stdout
               if fmt == "json":
-                  data = json.loads(raw)
+                  return json.loads(raw)
               elif fmt == "toml":
                   import tomllib
-                  data = tomllib.loads(raw)
-              else:
-                  raise SystemExit(f"::error::Unsupported format '{fmt}' for {path}")
-              for part in [p for p in selector.split(".") if p]:
-                  data = data[part]
-              return str(data)
+                  return tomllib.loads(raw)
+              raise SystemExit(f"::error::Unsupported format '{fmt}' for {path}")
 
           def aligned(actual, tag):
               # transform=strip-leading-v: accept either form, matching the file's existing convention
@@ -246,15 +441,18 @@ jobs:
           errors = []
           for e in vbf["entries"]:
               try:
-                  actual = value_at_sha(e["path"], sha, e["format"], e["selector"])
+                  data = data_at_sha(e["path"], sha, e["format"])
+                  # Every selector match (incl. array wildcards) MUST equal the tag.
+                  values = [str(c[k]) for c, k in refs(data, e["selector"])]
               except subprocess.CalledProcessError:
                   errors.append(f"  - {e['path']}: file missing at {sha[:8]}")
                   continue
-              except (KeyError, TypeError) as exc:
+              except (KeyError, TypeError, IndexError) as exc:
                   errors.append(f"  - {e['path']}: selector '{e['selector']}' not found ({exc})")
                   continue
-              if not aligned(actual, tag):
-                  errors.append(f"  - {e['path']}: {e['selector']} is '{actual}', expected '{tag}' (or '{tag.lstrip('v')}')")
+              for actual in values:
+                  if not aligned(actual, tag):
+                      errors.append(f"  - {e['path']}: {e['selector']} is '{actual}', expected '{tag}' (or '{tag.lstrip('v')}')")
 
           if errors:
               print("::error::Version-bearing files not aligned to target tag:")
@@ -283,7 +481,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.token }}
           TAG: ${{ inputs.tag }}
-          TARGET_SHA: ${{ steps.draft.outputs.target_sha }}
+          TARGET_SHA: ${{ steps.align.outputs.target_sha || steps.draft.outputs.target_sha }}
           DRY_RUN: ${{ inputs.dry_run }}
           VBF_SOURCE: ${{ steps.vbf.outputs.source }}
           VBF_COUNT: ${{ steps.vbf.outputs.count }}
@@ -329,7 +527,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.token }}
           TAG: ${{ inputs.tag }}
-          TARGET_SHA: ${{ steps.draft.outputs.target_sha }}
+          TARGET_SHA: ${{ steps.align.outputs.target_sha || steps.draft.outputs.target_sha }}
           DRY_RUN: ${{ inputs.dry_run }}
           ASSET_FILENAME: ${{ inputs.asset-filename }}
         run: |
@@ -473,7 +671,7 @@ jobs:
         if: ${{ inputs.dry_run != true && steps.app-token.outputs.token != '' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.token }}
-          TARGET_SHA: ${{ steps.draft.outputs.target_sha }}
+          TARGET_SHA: ${{ steps.align.outputs.target_sha || steps.draft.outputs.target_sha }}
         run: |
           set -euo pipefail
           # The cascade run may not have registered yet; this is a best-effort

--- a/docs/de/portfolio-app/setup.md
+++ b/docs/de/portfolio-app/setup.md
@@ -302,6 +302,49 @@ Derselbe Block gilt für `master`.
 
 ---
 
+## Versionstragende Datei-Ausrichtung (Primärpfad)
+
+Sobald die App installiert **und** als `develop`-Bypass-Actor benannt
+ist (der Phase-2-Block oben), kann ein Aufrufer den
+**workflow-getriebenen Primärpfad** für die Ausrichtung versionstragender
+Dateien (`spec/project/release-automation/` §Version-bearing file
+alignment) aktivieren, indem er `auto-align: true` an
+`reusable-release-publish.yml` übergibt. Mit gesetztem Opt-in und
+vorhandenem App-Token führt das Reusable vor der Verifikation nun aus:
+
+1. aktualisiert jede versionstragende Datei auf den Ziel-Tag gemäß ihrer
+   Transformation—unter Wahrung der bestehenden `v`-Präfix-Konvention
+   jeder Datei und mit Anpassung **jedes** Treffers eines Array-Selektors
+   wie `$.plugins[].version` in einer Multi-Plugin-`marketplace.json`;
+2. committet die Gesamtänderung als `chore(release): <tag>` auf
+   `develop`, autorisiert durch die App;
+3. pusht sie über den deklarierten Bypass und richtet das
+   `target_commitish` des Drafts auf den neuen Commit aus, damit der
+   veröffentlichte Tag exakt vom ausgerichteten Baum geschnitten wird.
+
+Das **Opt-in zusammen mit dem App-Token ist der Freischalt-Gate**: Der
+Align-Schritt läuft nur, wenn `auto-align: true` gesetzt ist **und** der
+Mint-Schritt ein Token erzeugt hat. Ohne das Opt-in, ohne die App oder
+bei einem Mint-Fehler wird der Schritt übersprungen und der Workflow
+fällt auf den **Operator-Pfad** zurück—ein Mensch
+öffnet einen `chore(release): <tag>`-PR, squash-merged ihn über die UI
+und dispatcht dann `release-publish`. Beide Pfade landen denselben
+`chore(release): <tag>`-Commit; nur die erzeugende Credential
+unterscheidet sich. Ein `dry_run`-Dispatch richtet lokal auf dem Runner
+aus und verifiziert, pusht aber nie und richtet den Draft nicht neu aus.
+
+!!! warning "Der erste echte Lauf validiert den geschützten Push"
+    Ein direkter Push auf `develop` unter `enforce_admins: true` mit
+    erforderlichen Status-Checks wird nur akzeptiert, wenn die App ein
+    echter Bypass-Actor ist. `dry_run` kann das nicht ausüben. Wird der
+    erste echte Push abgelehnt, ist die Abhilfe die Bypass-Actor-
+    Einstellung der Branch-Protection (der Phase-2-Block, über die
+    GitHub-UI angewendet, wenn die Probot-App ein Schutzfeld nicht
+    synchronisiert), keine Workflow-Änderung; der Lauf degradiert auf den
+    Operator-Fallback, statt das Release zu blockieren.
+
+---
+
 ## Verwandte Arbeit
 
 - Tracking-Issue: [#330](https://github.com/nolte/gh-plumbing/issues/330)

--- a/docs/en/portfolio-app/setup.md
+++ b/docs/en/portfolio-app/setup.md
@@ -298,41 +298,41 @@ The same block applies to `master`.
 
 ## Version-bearing file alignment (primary path)
 
-Once the App is installed **and** named as a `develop` bypass actor
-(the phase-2 block above), a caller can opt into the **workflow-driven
-primary path** for version-bearing-file alignment
-(`spec/project/release-automation/` §Version-bearing file alignment) by
-passing `auto-align: true` to `reusable-release-publish.yml`. With the
-opt-in set and an App token present, before verifying the reusable now:
+Phase 2 installs the App and names it as a `develop` bypass actor.
+After that, a caller can opt into the **workflow-driven primary path**
+for version-bearing-file alignment
+(`spec/project/release-automation/` §Version-bearing file alignment).
+The caller passes `auto-align: true` to `reusable-release-publish.yml`.
+With the opt-in set and an App token present, the reusable then does
+three things before it verifies:
 
-1. updates every version-bearing file to the target tag under its
-   transform—respecting each file's existing `v`-prefix convention,
-   and bumping **every** match of an array selector such as
-   `$.plugins[].version` in a multi-plugin `marketplace.json`;
-2. commits the aggregate change as `chore(release): <tag>` on
-   `develop`, authored by the App;
-3. pushes it through the declared bypass and realigns the draft's
-   `target_commitish` to the new commit, so the published tag is cut
-   from exactly the aligned tree.
+1. it updates every version-bearing file to the target tag under its
+   transform. It keeps each file's existing `v`-prefix convention and
+   bumps **every** match of an array selector such as
+   `$.plugins[].version` in a multi-plugin `marketplace.json`.
+2. it commits the aggregate change as `chore(release): <tag>` on
+   `develop` under the App's identity.
+3. it pushes the commit through the declared bypass and realigns the
+   draft's `target_commitish` to it. The published tag then comes from
+   exactly the aligned tree.
 
-The align step is **gated on both the opt-in and the App-token
-presence**: it runs only when `auto-align: true` **and** the mint step
-produced a token. Without the opt-in, without the App, or on a mint
-failure the step is skipped and the workflow falls back to the
-**operator path**—a human opens a `chore(release): <tag>` PR, squash-
+The align step needs **both the opt-in and the App token**. It runs
+only when `auto-align: true` meets a token from the mint step.
+Otherwise the workflow skips the step and falls back to the **operator
+path**. There, a human opens a `chore(release): <tag>` PR, squash-
 merges it through the UI, then dispatches `release-publish`. Both paths
-land the identical `chore(release): <tag>` commit shape; only the
+land the identical `chore(release): <tag>` commit shape. Only the
 credential that creates it differs. A `dry_run` dispatch aligns and
-verifies locally on the runner but never pushes or realigns the draft.
+verifies on the runner. It never pushes and never realigns the draft.
 
 !!! warning "First real run validates the protected push"
     A direct push to `develop` under `enforce_admins: true` with
-    required status checks is only honoured if the App is a genuine
-    bypass actor. `dry_run` can't exercise it. If the first real push
-    is rejected, the remediation is the branch-protection bypass-actor
-    setting (the phase-2 block, applied via the GitHub UI when the
-    Probot App doesn't sync a protection field), not a workflow change;
-    the run degrades to the operator fallback rather than wedging the
+    required status checks works only when the App is a genuine bypass
+    actor. `dry_run` can't exercise it. The remediation for a rejected
+    first push is the branch-protection bypass-actor setting—the
+    phase-2 block. An operator applies it through the GitHub UI when the
+    Probot App skips a protection field. It's not a workflow change.
+    The run degrades to the operator fallback rather than wedging the
     release.
 
 ---

--- a/docs/en/portfolio-app/setup.md
+++ b/docs/en/portfolio-app/setup.md
@@ -315,8 +315,8 @@ opt-in set and an App token present, before verifying the reusable now:
    `target_commitish` to the new commit, so the published tag is cut
    from exactly the aligned tree.
 
-The **opt-in plus the App-token presence are the enablement gate**: the
-align step runs only when `auto-align: true` **and** the mint step
+The align step is **gated on both the opt-in and the App-token
+presence**: it runs only when `auto-align: true` **and** the mint step
 produced a token. Without the opt-in, without the App, or on a mint
 failure the step is skipped and the workflow falls back to the
 **operator path**—a human opens a `chore(release): <tag>` PR, squash-

--- a/docs/en/portfolio-app/setup.md
+++ b/docs/en/portfolio-app/setup.md
@@ -296,6 +296,47 @@ The same block applies to `master`.
 
 ---
 
+## Version-bearing file alignment (primary path)
+
+Once the App is installed **and** named as a `develop` bypass actor
+(the phase-2 block above), a caller can opt into the **workflow-driven
+primary path** for version-bearing-file alignment
+(`spec/project/release-automation/` §Version-bearing file alignment) by
+passing `auto-align: true` to `reusable-release-publish.yml`. With the
+opt-in set and an App token present, before verifying the reusable now:
+
+1. updates every version-bearing file to the target tag under its
+   transform—respecting each file's existing `v`-prefix convention,
+   and bumping **every** match of an array selector such as
+   `$.plugins[].version` in a multi-plugin `marketplace.json`;
+2. commits the aggregate change as `chore(release): <tag>` on
+   `develop`, authored by the App;
+3. pushes it through the declared bypass and realigns the draft's
+   `target_commitish` to the new commit, so the published tag is cut
+   from exactly the aligned tree.
+
+The **opt-in plus the App-token presence are the enablement gate**: the
+align step runs only when `auto-align: true` **and** the mint step
+produced a token. Without the opt-in, without the App, or on a mint
+failure the step is skipped and the workflow falls back to the
+**operator path**—a human opens a `chore(release): <tag>` PR, squash-
+merges it through the UI, then dispatches `release-publish`. Both paths
+land the identical `chore(release): <tag>` commit shape; only the
+credential that creates it differs. A `dry_run` dispatch aligns and
+verifies locally on the runner but never pushes or realigns the draft.
+
+!!! warning "First real run validates the protected push"
+    A direct push to `develop` under `enforce_admins: true` with
+    required status checks is only honoured if the App is a genuine
+    bypass actor. `dry_run` can't exercise it. If the first real push
+    is rejected, the remediation is the branch-protection bypass-actor
+    setting (the phase-2 block, applied via the GitHub UI when the
+    Probot App doesn't sync a protection field), not a workflow change;
+    the run degrades to the operator fallback rather than wedging the
+    release.
+
+---
+
 ## Related work
 
 - Tracking issue: [#330](https://github.com/nolte/gh-plumbing/issues/330)

--- a/docs/en/portfolio-app/setup.md
+++ b/docs/en/portfolio-app/setup.md
@@ -58,7 +58,7 @@ permissions**:
 |---|---|---|
 | `Contents` | `Read and write` | Squash-merge to develop, edit releases, fast-forward master |
 | `Pull requests` | `Read and write` | `pascalgn/automerge-action` reads and merges PRs |
-| `Issues` | `Read and write` | Automatically close issues referenced via `Closes #N` / `Fixes #N` / `Resolves #N` in the PR body when the App squash-merges. GitHub only honours these autolinks when the merging actor has `Issues: write`; without this scope the autolinks parse correctly into `closingIssuesReferences` but the close never fires (observed end-to-end on #357 / #358). |
+| `Issues` | `Read and write` | Automatically close issues referenced via `Closes #N` / `Fixes #N` / `Resolves #N` in the PR body when the App squash-merges. GitHub only honours these closing references when the merging actor has `Issues: write`; without this scope the references parse correctly into `closingIssuesReferences` but the close never fires (observed end-to-end on #357 / #358). |
 | `Actions` | `Read-only` | `release-publish` reads `gh run list` for the post-publish cascade sanity check |
 | `Metadata` | `Read-only` | Mandatory baseline (GitHub sets this automatically and won't let you disable it) |
 


### PR DESCRIPTION
## Summary

Close the two #370 gaps in `reusable-release-publish.yml`: the workflow can now
align version-bearing files itself (the spec's "Primary path: Workflow-driven"),
and it understands array selectors like `$.plugins[].version`. Both halves are
additive and default to today's behaviour.

## Changes

- Add an opt-in `auto-align` input. When `auto-align: true` AND an App
  installation token is available, the reusable updates every version-bearing
  file to the target tag, commits `chore(release): <tag>` on develop authored by
  the App, pushes through the declared bypass, and realigns the draft's
  `target_commitish` to the new SHA.
- Add a shared `selectorlib.refs()` grammar (dot-path + `[]`/`[*]` wildcard),
  written once and imported by both the verify (read) and align (write) steps so
  the grammar can never drift between them.
- Verify every match of an array selector; add `$.plugins[].version` to the
  default claude-plugin detection, guarded on existence.
- Write format-preserving: JSON via an indent-detecting round-trip, TOML via a
  targeted regex (no new dependency).
- Re-resolve `TARGET_SHA` after the alignment commit; all downstream steps read
  `steps.align.outputs.target_sha || steps.draft.outputs.target_sha`.
- Document the now-available primary path in `docs/{en,de}/portfolio-app/setup.md`.

## Linked issues

Closes #370
Refs #330

## Testing

- `actionlint` (with bundled shellcheck) on the reusable: clean.
- Repo pre-commit (`check-yaml`, eof, trailing-whitespace) on all changed files: pass.
- Isolated unit test of the `selectorlib.refs()` + JSON/TOML write logic (13/13):
  scalar & wildcard read, strip-leading-v, v-convention preservation, minimal-diff
  writes, indent detection, mixed/empty `plugins[]` guards.
- Extracted the heredoc-written `selectorlib.py` exactly as the runner emits it and
  confirmed it imports and resolves selectors.
- Vale is CI-only in this repo (styles not synced locally); PR opens as Draft so the
  CI prose gate runs first.

## Risk / rollout notes

Additive and off-by-default: the primary path runs only with `auto-align: true`
**and** an App token, so existing consumers (including this repo, which has no
version-bearing files) are unaffected. Governing spec: `spec/project/release-automation/`
§"Primary path: Workflow-driven" in nolte/claude-shared (not vendored here).
Runtime risk: a direct push to protected `develop` is only honoured if the App is a
genuine bypass actor — `dry_run` can't exercise it; a rejected push degrades to the
operator-fallback path rather than wedging a release (documented in setup.md).