### PR TITLE
fix(release): degrade gracefully when primary-path align push is rejected

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -34,6 +34,14 @@ jobs:
       tag: ${{ inputs.tag }}
       dry_run: ${{ inputs.dry_run }}
       app-id: ${{ vars.PORTFOLIO_APP_ID }}
+      # Opt in to the workflow-driven primary path: when the App token is
+      # available the reusable aligns every version-bearing file, commits
+      # `chore(release): <tag>` on develop, and pushes (spec/project/
+      # release-automation/ §Version-bearing file alignment → Primary path).
+      # nolte-portfolio-app is a declared bypass actor on develop
+      # (.github/commons-settings.yml restrictions.apps); a push rejected by
+      # branch protection degrades gracefully to the operator fallback path.
+      auto-align: true
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
       app-private-key: ${{ secrets.PORTFOLIO_APP_PRIVATE_KEY }}

--- a/.github/workflows/reusable-release-publish.yml
+++ b/.github/workflows/reusable-release-publish.yml
@@ -387,24 +387,42 @@ jobs:
             echo "Committed chore(release): $TAG at $new_sha."
           fi
 
-          echo "target_sha=$new_sha" >> "$GITHUB_OUTPUT"
-
           if [[ "$DRY_RUN" == "true" ]]; then
+            # Dry run: expose the locally-built commit so the Verify step can read
+            # the aligned tree via `git show`, but never push or realign the draft.
+            echo "target_sha=$new_sha" >> "$GITHUB_OUTPUT"
             echo "::notice::Dry run — aligned locally at ${new_sha:0:8}; not pushing to develop or realigning the draft."
             { echo; echo "### Alignment (dry run)"; echo; echo "- Would commit/push \`chore(release): $TAG\` and realign the draft to \`${new_sha:0:8}\`."; } >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
-          # Push the alignment commit (if any) and realign the draft target to the
-          # aligned SHA so the published tag is cut from exactly this commit. The
-          # push authority is the App being a declared bypass actor on develop
-          # (branch-protection config, not a workflow `permissions:` key); per
-          # spec the push respects `enforce_admins: true` — the bypass is declared,
-          # not stolen. A rejected push degrades to the operator fallback path.
+          # Push the alignment commit (if any). The push authority is the App being
+          # a declared bypass actor on develop (branch-protection config, not a
+          # workflow `permissions:` key); per spec the push respects
+          # `enforce_admins: true` — the bypass is declared, not stolen.
+          #
+          # A rejected push (e.g. develop's branch protection refuses a direct push
+          # because the App is not a permitted bypass actor) MUST NOT wedge the
+          # release. Degrade to the operator fallback path: warn, emit no
+          # target_sha, and skip the draft realign so the Verify step below falls
+          # back to steps.draft.outputs.target_sha — the unaligned draft tree — and
+          # surfaces the operator-fallback message
+          # (spec/project/release-automation/ §Fallback path).
           if [[ "$committed" == "true" ]]; then
-            git push origin HEAD:develop
+            if ! git push origin HEAD:develop; then
+              msg="Primary-path push of 'chore(release): $TAG' to develop was rejected (the App may not be a permitted bypass actor for direct pushes to develop). Falling back to the operator path: open a 'chore(release): $TAG' PR aligning every version-bearing file (spec/project/release-automation/ §Fallback path), then re-run release-publish."
+              echo "::warning::$msg"
+              { echo; echo "### ⚠️ Alignment push rejected (operator fallback)"; echo; echo "$msg"; } >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
             echo "::notice::Pushed alignment commit to develop."
           fi
+
+          # Push succeeded, or no commit was needed because the tree was already
+          # aligned at develop HEAD — in both cases new_sha is reachable on develop.
+          # Expose it and realign the draft target to that exact SHA so the
+          # published tag is cut from this commit.
+          echo "target_sha=$new_sha" >> "$GITHUB_OUTPUT"
           gh release edit "$TAG" --target "$new_sha"
           echo "::notice::Realigned draft '$TAG' target to ${new_sha:0:8}."
           { echo; echo "### Alignment"; echo; echo "- Aligned version-bearing files and set draft '$TAG' target to \`${new_sha:0:8}\`."; } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Follow-up to #381 (closes the last gap on #370). The reusable-release-publish
Align step documented — in both the step comment and the `auto-align` input
description — that a push rejected by develop's branch protection "degrades
gracefully to the operator fallback path", but the code did not honour that
contract. This makes the behaviour match the documentation and switches the
primary path on for this repo.

## Changes

- Wrap the primary-path `git push origin HEAD:develop` in `if ! git push`: on
  rejection, warn, emit no `target_sha`, and skip the draft realign, so the
  Verify step falls back to the draft SHA and surfaces the operator-fallback
  message instead of failing the job and wedging the release.
- Emit `steps.align.outputs.target_sha` only on the push-success and
  already-aligned paths (and, for dry runs, the local commit) — never after a
  rejected push.
- Enable the workflow-driven primary path for this repo by passing
  `auto-align: true` from the `release-publish.yml` caller.

## Linked issues

Refs #370
Refs #381

## Testing

- `actionlint` clean on both `reusable-release-publish.yml` and `release-publish.yml`.
- `pre-commit` (check-yaml, end-of-file-fixer, trailing-whitespace) passes on both files.
- Manual branch trace of the Align step confirms all four paths: already-aligned,
  dry-run, push-success, and push-rejected (errexit correctly suppressed inside
  `if ! git push`, so a rejected push exits 0 with a warning rather than failing).

## Risk / rollout notes

Low–medium. Additive to a merged feature; the fallback path is unchanged.
The `auto-align: true` caller switch activates the primary path on the next
release of this repo: nolte-portfolio-app is a declared bypass actor on develop
(commons-settings.yml `restrictions.apps`). The DD5 runtime unknown — whether the
App may actually push directly to protected develop — is exercised for the first
time on that release; if branch protection rejects the direct push, this change
ensures it degrades to the operator fallback (open a `chore(release): <tag>` PR)
rather than wedging the release. No rollback needed; revert the caller's
`auto-align` line to disable the primary path again.