### PR TITLE
feat(project): author the planning-suite mission for gh-plumbing (#262)

### DIFF
--- a/AUDIENCES.md
+++ b/AUDIENCES.md
@@ -18,7 +18,7 @@ asset classes for downstream GitHub repositories:
    consumed via `github>nolte/gh-plumbing//renovate-configs/common`.
 
 **Inside the boundary:** the contents of `.github/workflows/reusable-*`,
-`.github/commons-*.yml`, `renovate-configs/`, and the MkDocs site
+`.github/commons-*.yml`, `renovate-configs/`, and the `MkDocs` site
 (`docs/`, `mkdocs.yml`) that documents the published surface.
 
 **Outside the boundary:** this repository's own dog-fooding wrapper
@@ -120,7 +120,7 @@ peripheral). Mark a whole category as `none — <reason>` when it doesn't apply.
     downstream organisations) the maintainer should communicate with
     directly?
 - **Open-source readers seeking patterns**, _category_: indirect ·
-  _surface_: published MkDocs site (`has_pages: true`); public README;
+  _surface_: published `MkDocs` site (`has_pages: true`); public README;
   browsing the GitHub repository · _expects_: working examples of
   reusable workflows and Probot `_extends:` for adoption in their own
   projects · _status_: `assumed` · _criticality_: peripheral
@@ -132,7 +132,7 @@ peripheral). Mark a whole category as `none — <reason>` when it doesn't apply.
   tag-pinning behaviour. Concrete contracts (which inputs and secrets
   each reusable workflow guarantees stable; deprecation policy length)
   aren't yet codified in any spec.
-- The MkDocs site doubles as I2's interaction surface but lacks an audit
+- The `MkDocs` site doubles as I2's interaction surface but lacks an audit
   for that audience, so see `docs-freshness-checker` for routine drift
   checks.
 

--- a/docs/en/workflows/coverage.md
+++ b/docs/en/workflows/coverage.md
@@ -2,10 +2,10 @@
 
 Runs a project's tests and surfaces the coverage report in the GitHub Actions job summary, so consumers see coverage without an external service. Two variants cover the common ecosystems.
 
-- [`reusable-python-coverage.yaml`](#python) — pytest with pytest-cov
-- [`reusable-nodejs-coverage.yaml`](#nodejs) — Vitest or Jest via the Istanbul `json-summary` report
+- [`reusable-python-coverage.yaml`](#python): `pytest` with `pytest-cov`
+- [`reusable-nodejs-coverage.yaml`](#nodejs): `Vitest` or Jest via the Istanbul `json-summary` report
 
-Both render a Markdown table into `$GITHUB_STEP_SUMMARY`—even when the tests fail—and expose an optional `fail-under` gate.
+Both render a Markdown table into `$GITHUB_STEP_SUMMARY` (even when the tests fail) and expose an optional `fail-under` gate.
 
 ---
 
@@ -36,7 +36,7 @@ jobs:
 ```
 
 !!! tip "json-summary report"
-    The `test-command` (default `npm test`) must write an Istanbul `json-summary` report to `coverage-summary-path` (default `coverage/coverage-summary.json`). Both Vitest (`--coverage.reporter=json-summary`) and Jest (`--coverageReporters=json-summary`) emit this format.
+    The `test-command` (default `npm test`) must write an Istanbul `json-summary` report to `coverage-summary-path` (default `coverage/coverage-summary.json`). Both `Vitest` (`--coverage.reporter=json-summary`) and Jest (`--coverageReporters=json-summary`) emit this format.
 
 ---
 

--- a/project/features/reusable-workflow-adoption.md
+++ b/project/features/reusable-workflow-adoption.md
@@ -23,14 +23,15 @@ consistency_check:
 
 ## Description
 
-F-1 is the mission-verifying feature for `gh-plumbing`'s shipped MVP: it captures
-the adoption contract of the reusable GitHub Actions workflow library (R-1). A
-downstream `nolte/*` repository adopts a reusable workflow by referencing it at a
-published tag; the contract is met when that reference resolves and the
-downstream pipeline runs green. This already holds across the portfolio, because
-the `automerge`, docs, and spelling checks in the sibling repositories all route
-through `nolte/gh-plumbing/.github/workflows/reusable-*.yaml@<tag>`, so the
-feature is recorded `done` as part of the retroactive MVP reconciliation (issue
+F-1 is the mission-verifying feature for `gh-plumbing`'s shipped minimum viable
+product. It captures the adoption contract of the reusable GitHub Actions
+workflow library (R-1). A downstream `nolte/*` repository adopts a reusable
+workflow by referencing it at a published tag. The contract holds when that
+reference resolves and the downstream pipeline runs green. This already holds
+across the portfolio, because the `automerge`, docs, and spelling checks in the
+sibling repositories all route through
+`nolte/gh-plumbing/.github/workflows/reusable-*.yaml@<tag>`. The retroactive
+reconciliation therefore records this feature as `done` (issue
 nolte/claude-shared#262).
 
 ## Acceptance criteria
@@ -40,24 +41,24 @@ nolte/claude-shared#262).
   (`uses: nolte/gh-plumbing/.github/workflows/reusable-<name>.yaml@<tag>`) and its
   pipeline run completes green. _(This is the sprint value verifier.)_
 - [x] **acceptance-2** Every published `gh-plumbing` tag is a usable pinning
-  target (consumers pin to tags, not to `@develop`).
+  target. Consumers pin to tags, not to `@develop`.
 - [x] **acceptance-3** A breaking change to a reusable workflow's input or secret
   contract ships behind a new tag, so existing downstream pins keep resolving.
 
 ## Test hooks
 
-- **acceptance-1**: observable in any sibling repository's Actions run whose job
-  calls a `reusable-*.yaml` (for example the `automerge`, docs, and spelling
+- **acceptance-1**: any sibling repository's Actions run whose job calls a
+  `reusable-*.yaml` shows this (for example the `automerge`, docs, and spelling
   checks on `nolte/pre-commit-hooks` and `nolte/kamerplanter-ha`); passing.
 - **acceptance-2**: the release-drafter and publish workflow produces tag
-  releases; consumers pin `@<tag>`; passing.
+  releases, and consumers pin `@<tag>`; passing.
 - **acceptance-3**: manual review of the tag and versioning convention; passing.
 
 ## Consistency notes
 
-Retroactive documentation feature: the underlying capability
-(`reusable-github-actions-workflows`) predates the planning suite. No new
-implementation is introduced; the feature exists so the mission's
+This is a retroactive documentation feature. The underlying capability
+(`reusable-github-actions-workflows`) predates the planning suite. This feature
+introduces no new implementation. It exists so the mission's
 `verifies_via: F-1:acceptance-1` and sprint 1's `value_statement` resolve to a
 real acceptance criterion.
 

--- a/project/features/reusable-workflow-adoption.md
+++ b/project/features/reusable-workflow-adoption.md
@@ -1,0 +1,68 @@
+---
+id: F-1
+title: Reusable-workflow adoption
+status: done
+roadmap_item: R-1
+sprint: 1
+created: 2026-07-02
+ended: 2026-07-02
+verifies_sprint_value: acceptance-1
+consistency_check:
+  performed_at: 2026-07-02
+  agent_version: manual-fallback (retroactive; feature-consistency-reviewer not run cross-repo)
+  findings:
+    - kind: clean
+      target: project/features/
+      resolution: proceed
+      evidence: "project/features/ empty (first decomposition) — no feature-to-feature overlap possible."
+    - kind: prior-art
+      target: .github/workflows/reusable-pre-commit.yaml
+      resolution: proceed
+      evidence: "The reusable-*.yaml workflow library already exists and is consumed portfolio-wide; F-1 documents the shipped adoption contract, it does not build new workflows."
+---
+
+## Description
+
+F-1 is the mission-verifying feature for gh-plumbing's shipped MVP: it captures
+the adoption contract of the reusable GitHub Actions workflow library (R-1). A
+downstream `nolte/*` repository adopts a reusable workflow by referencing it at a
+published tag; the contract is met when that reference resolves and the
+downstream pipeline runs green. This already holds across the portfolio — the
+automerge, docs, and spelling checks in the sibling repositories all route
+through `nolte/gh-plumbing/.github/workflows/reusable-*.yaml@<tag>` — so the
+feature is recorded `done` as part of the retroactive MVP reconciliation
+(issue nolte/claude-shared#262).
+
+## Acceptance criteria
+
+- [x] **acceptance-1** A downstream `nolte/*` repository references a
+  `reusable-*.yaml` workflow at a published tag (`uses:
+  nolte/gh-plumbing/.github/workflows/reusable-<name>.yaml@<tag>`) and its
+  pipeline run completes green. _(This is the sprint value verifier.)_
+- [x] **acceptance-2** Every published gh-plumbing tag is a usable pinning target
+  (consumers pin to tags, not to `@develop`).
+- [x] **acceptance-3** A breaking change to a reusable workflow's input or secret
+  contract ships behind a new tag, so existing downstream pins keep resolving.
+
+## Test hooks
+
+- **acceptance-1** — observable in any sibling repo's Actions run whose job calls
+  a `reusable-*.yaml` (e.g. the automerge / docs / spelling checks on
+  nolte/pre-commit-hooks, nolte/kamerplanter-ha) — passing.
+- **acceptance-2** — release-drafter/publish workflow produces tag releases;
+  consumers pin `@<tag>` — passing.
+- **acceptance-3** — manual review of the tag/versioning convention — passing.
+
+## Consistency notes
+
+Retroactive documentation feature: the underlying capability
+(`reusable-github-actions-workflows`) predates the planning suite. No new
+implementation is introduced; the feature exists so the mission's `verifies_via:
+F-1:acceptance-1` and sprint 1's `value_statement` resolve to a real acceptance
+criterion.
+
+## References
+
+- `project/portfolio.yml` capability `reusable-github-actions-workflows`
+- `AUDIENCES.md` audience "Downstream repositories consuming reusable workflows"
+- `README.md` §Workflows (the published reusable-*.yaml catalogue)

--- a/project/features/reusable-workflow-adoption.md
+++ b/project/features/reusable-workflow-adoption.md
@@ -14,7 +14,7 @@ consistency_check:
     - kind: clean
       target: project/features/
       resolution: proceed
-      evidence: "project/features/ empty (first decomposition) — no feature-to-feature overlap possible."
+      evidence: "project/features/ empty (first decomposition); no feature-to-feature overlap possible."
     - kind: prior-art
       target: .github/workflows/reusable-pre-commit.yaml
       resolution: proceed
@@ -23,46 +23,46 @@ consistency_check:
 
 ## Description
 
-F-1 is the mission-verifying feature for gh-plumbing's shipped MVP: it captures
+F-1 is the mission-verifying feature for `gh-plumbing`'s shipped MVP: it captures
 the adoption contract of the reusable GitHub Actions workflow library (R-1). A
 downstream `nolte/*` repository adopts a reusable workflow by referencing it at a
 published tag; the contract is met when that reference resolves and the
-downstream pipeline runs green. This already holds across the portfolio — the
-automerge, docs, and spelling checks in the sibling repositories all route
-through `nolte/gh-plumbing/.github/workflows/reusable-*.yaml@<tag>` — so the
-feature is recorded `done` as part of the retroactive MVP reconciliation
-(issue nolte/claude-shared#262).
+downstream pipeline runs green. This already holds across the portfolio, because
+the `automerge`, docs, and spelling checks in the sibling repositories all route
+through `nolte/gh-plumbing/.github/workflows/reusable-*.yaml@<tag>`, so the
+feature is recorded `done` as part of the retroactive MVP reconciliation (issue
+nolte/claude-shared#262).
 
 ## Acceptance criteria
 
 - [x] **acceptance-1** A downstream `nolte/*` repository references a
-  `reusable-*.yaml` workflow at a published tag (`uses:
-  nolte/gh-plumbing/.github/workflows/reusable-<name>.yaml@<tag>`) and its
+  `reusable-*.yaml` workflow at a published tag
+  (`uses: nolte/gh-plumbing/.github/workflows/reusable-<name>.yaml@<tag>`) and its
   pipeline run completes green. _(This is the sprint value verifier.)_
-- [x] **acceptance-2** Every published gh-plumbing tag is a usable pinning target
-  (consumers pin to tags, not to `@develop`).
+- [x] **acceptance-2** Every published `gh-plumbing` tag is a usable pinning
+  target (consumers pin to tags, not to `@develop`).
 - [x] **acceptance-3** A breaking change to a reusable workflow's input or secret
   contract ships behind a new tag, so existing downstream pins keep resolving.
 
 ## Test hooks
 
-- **acceptance-1** — observable in any sibling repo's Actions run whose job calls
-  a `reusable-*.yaml` (e.g. the automerge / docs / spelling checks on
-  nolte/pre-commit-hooks, nolte/kamerplanter-ha) — passing.
-- **acceptance-2** — release-drafter/publish workflow produces tag releases;
-  consumers pin `@<tag>` — passing.
-- **acceptance-3** — manual review of the tag/versioning convention — passing.
+- **acceptance-1**: observable in any sibling repository's Actions run whose job
+  calls a `reusable-*.yaml` (for example the `automerge`, docs, and spelling
+  checks on `nolte/pre-commit-hooks` and `nolte/kamerplanter-ha`); passing.
+- **acceptance-2**: the release-drafter and publish workflow produces tag
+  releases; consumers pin `@<tag>`; passing.
+- **acceptance-3**: manual review of the tag and versioning convention; passing.
 
 ## Consistency notes
 
 Retroactive documentation feature: the underlying capability
 (`reusable-github-actions-workflows`) predates the planning suite. No new
-implementation is introduced; the feature exists so the mission's `verifies_via:
-F-1:acceptance-1` and sprint 1's `value_statement` resolve to a real acceptance
-criterion.
+implementation is introduced; the feature exists so the mission's
+`verifies_via: F-1:acceptance-1` and sprint 1's `value_statement` resolve to a
+real acceptance criterion.
 
 ## References
 
 - `project/portfolio.yml` capability `reusable-github-actions-workflows`
 - `AUDIENCES.md` audience "Downstream repositories consuming reusable workflows"
-- `README.md` §Workflows (the published reusable-*.yaml catalogue)
+- `README.md` §Workflows (the published `reusable-*.yaml` catalogue)

--- a/project/goals.md
+++ b/project/goals.md
@@ -1,0 +1,25 @@
+# Vision
+
+gh-plumbing is the nolte portfolio's single source of reusable CI/CD and
+repository-governance configuration: a library of reusable GitHub Actions
+workflows, shared Probot app configuration commons, and shared Renovate presets
+that downstream `nolte/*` repositories consume **by reference** (workflow `uses:`,
+Probot `_extends:`, Renovate `extends:`) so they get consistent pipelines and
+governance without reimplementing or copy-pasting boilerplate. It is a
+configuration-only repository with no application code and no running service.
+
+## Outcomes
+
+- **O-1** — Downstream repositories run consistent CI/CD by calling gh-plumbing's
+  reusable GitHub Actions workflows at a pinned tag instead of duplicating
+  pipeline YAML. _(audience: Downstream repositories consuming reusable workflows)_
+- **O-2** — Downstream repositories inherit one repository-governance baseline
+  (labels, branch protection, housekeeping) by extending gh-plumbing's Probot
+  configuration commons rather than maintaining per-repo settings.
+  _(audience: Downstream repositories extending Probot configurations)_
+- **O-3** — Downstream repositories keep dependency-update behaviour consistent by
+  extending gh-plumbing's shared Renovate presets.
+  _(audience: Downstream repositories consuming Renovate presets)_
+- **O-4** — The maintainer evolves the shared surface safely, with tag-immutable
+  releases and green CI so downstream pins stay stable across changes.
+  _(audience: Repository maintainer (nolte))_

--- a/project/goals.md
+++ b/project/goals.md
@@ -1,25 +1,25 @@
 # Vision
 
-gh-plumbing is the nolte portfolio's single source of reusable CI/CD and
+`gh-plumbing` is the `nolte` portfolio's single source of reusable CI/CD and
 repository-governance configuration: a library of reusable GitHub Actions
-workflows, shared Probot app configuration commons, and shared Renovate presets
-that downstream `nolte/*` repositories consume **by reference** (workflow `uses:`,
-Probot `_extends:`, Renovate `extends:`) so they get consistent pipelines and
-governance without reimplementing or copy-pasting boilerplate. It is a
+workflows, shared `Probot` app configuration commons, and shared `Renovate`
+presets that downstream `nolte/*` repositories consume **by reference** (workflow
+`uses:`, `Probot` `_extends:`, `Renovate` `extends:`) so they get consistent
+pipelines and governance without duplicating boilerplate. It's a
 configuration-only repository with no application code and no running service.
 
 ## Outcomes
 
-- **O-1** — Downstream repositories run consistent CI/CD by calling gh-plumbing's
+- **O-1**: downstream repositories run consistent CI/CD by calling `gh-plumbing`'s
   reusable GitHub Actions workflows at a pinned tag instead of duplicating
   pipeline YAML. _(audience: Downstream repositories consuming reusable workflows)_
-- **O-2** — Downstream repositories inherit one repository-governance baseline
-  (labels, branch protection, housekeeping) by extending gh-plumbing's Probot
-  configuration commons rather than maintaining per-repo settings.
+- **O-2**: downstream repositories inherit one repository-governance baseline
+  (labels, branch protection, housekeeping) by extending `gh-plumbing`'s `Probot`
+  configuration commons rather than maintaining per-repository settings.
   _(audience: Downstream repositories extending Probot configurations)_
-- **O-3** — Downstream repositories keep dependency-update behaviour consistent by
-  extending gh-plumbing's shared Renovate presets.
+- **O-3**: downstream repositories keep dependency-update behaviour consistent by
+  extending `gh-plumbing`'s shared `Renovate` presets.
   _(audience: Downstream repositories consuming Renovate presets)_
-- **O-4** — The maintainer evolves the shared surface safely, with tag-immutable
-  releases and green CI so downstream pins stay stable across changes.
+- **O-4**: the maintainer evolves the shared surface with tag-immutable releases
+  and green CI, so downstream pins stay stable across changes.
   _(audience: Repository maintainer (nolte))_

--- a/project/goals.md
+++ b/project/goals.md
@@ -1,12 +1,13 @@
 # Vision
 
 `gh-plumbing` is the `nolte` portfolio's single source of reusable CI/CD and
-repository-governance configuration: a library of reusable GitHub Actions
-workflows, shared `Probot` app configuration commons, and shared `Renovate`
-presets that downstream `nolte/*` repositories consume **by reference** (workflow
-`uses:`, `Probot` `_extends:`, `Renovate` `extends:`) so they get consistent
-pipelines and governance without duplicating boilerplate. It's a
-configuration-only repository with no application code and no running service.
+repository-governance configuration. It publishes a library of reusable GitHub
+Actions workflows, shared `Probot` app configuration commons, and shared
+`Renovate` presets. Downstream `nolte/*` repositories consume these **by
+reference** (workflow `uses:`, `Probot` `_extends:`, `Renovate` `extends:`).
+They get consistent pipelines and governance without duplicating boilerplate.
+The repository holds configuration only, with no application code and no running
+service.
 
 ## Outcomes
 

--- a/project/mission.md
+++ b/project/mission.md
@@ -1,5 +1,5 @@
 ---
-mission_statement: "gh-plumbing gives downstream nolte/* repositories one centralised, tag-pinned source of reusable GitHub Actions workflows, Probot governance commons, and Renovate presets, so they achieve consistent CI/CD and repository governance without reimplementing or copy-pasting pipeline and configuration boilerplate."
+mission_statement: "gh-plumbing gives downstream nolte/* repositories one centralised, tag-pinned source of reusable GitHub Actions workflows, Probot governance commons, and Renovate presets, so they achieve consistent CI/CD and repository governance without duplicating or copy-pasting pipeline and configuration boilerplate."
 relevant_outcomes: [O-1, O-2, O-3, O-4]
 audiences:
   - Downstream repositories consuming reusable workflows
@@ -16,63 +16,64 @@ revised_at: null
 
 ## Statement
 
-gh-plumbing gives downstream `nolte/*` repositories one centralised, tag-pinned
-source of reusable GitHub Actions workflows, Probot governance commons, and
-Renovate presets, so they achieve consistent CI/CD and repository governance
-without reimplementing or copy-pasting pipeline and configuration boilerplate.
+`gh-plumbing` gives downstream `nolte/*` repositories one centralised, tag-pinned
+source of reusable GitHub Actions workflows, `Probot` governance commons, and
+`Renovate` presets, so they achieve consistent CI/CD and repository governance
+without duplicating or copy-pasting pipeline and configuration boilerplate.
 
-- **Specific** — the statement names *what* (reusable workflows + Probot commons
-  + Renovate presets, published by reference) and *for whom* (the downstream
-  consumer audiences plus the maintainer, resolved in `audiences`).
-- **Measurable** — `verifies_via: F-1:acceptance-1`: the mission is measurably met
-  when a downstream repository pins a `reusable-*.yaml` at a tag and its pipeline
-  runs green (F-1's acceptance criterion 1).
-- **Achievable** — the MVP is the three already-shipped capabilities
+- **Specific**: the statement names *what* (reusable workflows plus `Probot`
+  commons plus `Renovate` presets, published by reference) and *for whom* (the
+  downstream consumer audiences plus the maintainer, resolved in `audiences`).
+- **Measurable**: `verifies_via: F-1:acceptance-1`. The mission is measurably met
+  when a downstream repository pins a `reusable-*.yaml` workflow at a tag and its
+  pipeline runs green (F-1's acceptance criterion 1).
+- **Achievable**: the MVP is the three already-shipped capabilities
   (`reusable-github-actions-workflows`, `probot-commons-config`,
-  `renovate-shared-presets`); roadmap items R-1..R-3 are `mvp: true`, `detail:
-  fine`, `target_sprint: 1`.
-- **Relevant** — `relevant_outcomes: [O-1, O-2, O-3, O-4]`, each resolving to an
+  `renovate-shared-presets`); roadmap items R-1 through R-3 are `mvp: true`,
+  `detail: fine`, `target_sprint: 1`.
+- **Relevant**: `relevant_outcomes: [O-1, O-2, O-3, O-4]`, each resolving to an
   outcome in `project/goals.md`.
-- **Time-bound** — `time_bound: { kind: mvp_completion }`; the bound is the moment
+- **Time-bound**: `time_bound: { kind: mvp_completion }`. The bound is the moment
   the shipped-capability MVP is recorded as achieved, not a calendar date.
 
 ## Audiences
 
-- **Downstream repositories consuming reusable workflows** — the MVP delivers a
+- **Downstream repositories consuming reusable workflows**: the MVP delivers a
   library of `reusable-*.yaml` workflows callable via
   `uses: nolte/gh-plumbing/.github/workflows/reusable-<name>.yaml@<tag>`, so a
-  consumer gets pre-commit, MkDocs, Vale, automerge, release-drafter/publish,
-  Docker, Ansible, Terraform, Trivy, and coverage pipelines without writing its
-  own.
-- **Downstream repositories extending Probot configurations** — the MVP delivers
+  consumer gets `pre-commit`, `mkdocs`, `Vale`, `automerge`, release-drafter and
+  publish, Docker, Ansible, Terraform, `Trivy`, and coverage pipelines without
+  writing its own.
+- **Downstream repositories extending Probot configurations**: the MVP delivers
   `.github/commons-*.yml` presets (settings, boring-cyborg, release-drafter,
   stale) that a consumer inherits via `_extends:`, so labels, branch protection,
   and housekeeping stay uniform across the portfolio from one source.
-- **Downstream repositories consuming Renovate presets** — the MVP delivers
+- **Downstream repositories consuming Renovate presets**: the MVP delivers
   `renovate-configs/common` that a consumer extends via
   `extends: ["github>nolte/gh-plumbing//renovate-configs/common"]`, so
   dependency-update grouping, scheduling, and labelling behave consistently.
-- **Repository maintainer (nolte)** — the MVP delivers a single place to evolve
-  the shared surface, with tag-immutable releases and green CI so downstream
-  pins remain stable when the surface changes.
+- **Repository maintainer (`nolte`)**: the MVP delivers a single place to evolve
+  the shared surface, with tag-immutable releases and green CI so downstream pins
+  remain stable when the surface changes.
 
 ## Verification
 
-The mission is verified by feature **F-1 — Reusable-workflow adoption**, acceptance
+The mission is verified by feature **F-1: Reusable-workflow adoption**, acceptance
 criterion 1: *"A downstream `nolte/*` repository references a `reusable-*.yaml`
 workflow at a published tag and its pipeline run completes green."* This is the
 `verifies_sprint_value` criterion for sprint 0001; it already holds across the
-portfolio (every automerge/docs/spelling run in the sibling repos routes through
-these workflows), so the shipped-capability MVP is recorded as `achieved`.
+portfolio (every `automerge`, docs, and spelling run in the sibling repositories
+routes through these workflows), so the shipped-capability MVP is recorded as
+`achieved`.
 
 ## Source
 
-- **Audience artefact**: `AUDIENCES.md` at the gh-plumbing repo root (consulted at
-  its current develop HEAD); the four `audiences` entries are the primary D1/D2/D3
-  direct-consumer audiences plus the maintainer.
+- **Audience artefact**: `AUDIENCES.md` at the `gh-plumbing` repository root
+  (consulted at its current develop HEAD); the four `audiences` entries are the
+  primary D1, D2, and D3 direct-consumer audiences plus the maintainer.
 - **Outcomes referenced**: O-1, O-2, O-3, O-4 from `project/goals.md`.
-- **Authored by**: `mission-define` cascade (issue nolte/claude-shared#262
-  mission-authoring backfill), 2026-07-02. The MVP is modelled retroactively —
-  gh-plumbing's three capabilities were already `status: active` when the
-  planning suite was adopted, so R-1..R-3 are recorded as `status: done` and
-  `mvp_status` opens at `achieved` rather than `defining`.
+- **Authored by**: the `mission-define` cascade (issue nolte/claude-shared#262
+  mission-authoring backfill), 2026-07-02. The MVP is modelled retroactively:
+  `gh-plumbing`'s three capabilities were already `status: active` when the
+  planning suite was adopted, so R-1 through R-3 are recorded as `status: done`
+  and `mvp_status` opens at `achieved` rather than `defining`.

--- a/project/mission.md
+++ b/project/mission.md
@@ -1,0 +1,78 @@
+---
+mission_statement: "gh-plumbing gives downstream nolte/* repositories one centralised, tag-pinned source of reusable GitHub Actions workflows, Probot governance commons, and Renovate presets, so they achieve consistent CI/CD and repository governance without reimplementing or copy-pasting pipeline and configuration boilerplate."
+relevant_outcomes: [O-1, O-2, O-3, O-4]
+audiences:
+  - Downstream repositories consuming reusable workflows
+  - Downstream repositories extending Probot configurations
+  - Downstream repositories consuming Renovate presets
+  - Repository maintainer (nolte)
+verifies_via: F-1:acceptance-1
+time_bound:
+  kind: mvp_completion
+mvp_status: achieved
+created: 2026-07-02
+revised_at: null
+---
+
+## Statement
+
+gh-plumbing gives downstream `nolte/*` repositories one centralised, tag-pinned
+source of reusable GitHub Actions workflows, Probot governance commons, and
+Renovate presets, so they achieve consistent CI/CD and repository governance
+without reimplementing or copy-pasting pipeline and configuration boilerplate.
+
+- **Specific** — the statement names *what* (reusable workflows + Probot commons
+  + Renovate presets, published by reference) and *for whom* (the downstream
+  consumer audiences plus the maintainer, resolved in `audiences`).
+- **Measurable** — `verifies_via: F-1:acceptance-1`: the mission is measurably met
+  when a downstream repository pins a `reusable-*.yaml` at a tag and its pipeline
+  runs green (F-1's acceptance criterion 1).
+- **Achievable** — the MVP is the three already-shipped capabilities
+  (`reusable-github-actions-workflows`, `probot-commons-config`,
+  `renovate-shared-presets`); roadmap items R-1..R-3 are `mvp: true`, `detail:
+  fine`, `target_sprint: 1`.
+- **Relevant** — `relevant_outcomes: [O-1, O-2, O-3, O-4]`, each resolving to an
+  outcome in `project/goals.md`.
+- **Time-bound** — `time_bound: { kind: mvp_completion }`; the bound is the moment
+  the shipped-capability MVP is recorded as achieved, not a calendar date.
+
+## Audiences
+
+- **Downstream repositories consuming reusable workflows** — the MVP delivers a
+  library of `reusable-*.yaml` workflows callable via
+  `uses: nolte/gh-plumbing/.github/workflows/reusable-<name>.yaml@<tag>`, so a
+  consumer gets pre-commit, MkDocs, Vale, automerge, release-drafter/publish,
+  Docker, Ansible, Terraform, Trivy, and coverage pipelines without writing its
+  own.
+- **Downstream repositories extending Probot configurations** — the MVP delivers
+  `.github/commons-*.yml` presets (settings, boring-cyborg, release-drafter,
+  stale) that a consumer inherits via `_extends:`, so labels, branch protection,
+  and housekeeping stay uniform across the portfolio from one source.
+- **Downstream repositories consuming Renovate presets** — the MVP delivers
+  `renovate-configs/common` that a consumer extends via
+  `extends: ["github>nolte/gh-plumbing//renovate-configs/common"]`, so
+  dependency-update grouping, scheduling, and labelling behave consistently.
+- **Repository maintainer (nolte)** — the MVP delivers a single place to evolve
+  the shared surface, with tag-immutable releases and green CI so downstream
+  pins remain stable when the surface changes.
+
+## Verification
+
+The mission is verified by feature **F-1 — Reusable-workflow adoption**, acceptance
+criterion 1: *"A downstream `nolte/*` repository references a `reusable-*.yaml`
+workflow at a published tag and its pipeline run completes green."* This is the
+`verifies_sprint_value` criterion for sprint 0001; it already holds across the
+portfolio (every automerge/docs/spelling run in the sibling repos routes through
+these workflows), so the shipped-capability MVP is recorded as `achieved`.
+
+## Source
+
+- **Audience artefact**: `AUDIENCES.md` at the gh-plumbing repo root (consulted at
+  its current develop HEAD); the four `audiences` entries are the primary D1/D2/D3
+  direct-consumer audiences plus the maintainer.
+- **Outcomes referenced**: O-1, O-2, O-3, O-4 from `project/goals.md`.
+- **Authored by**: `mission-define` cascade (issue nolte/claude-shared#262
+  mission-authoring backfill), 2026-07-02. The MVP is modelled retroactively —
+  gh-plumbing's three capabilities were already `status: active` when the
+  planning suite was adopted, so R-1..R-3 are recorded as `status: done` and
+  `mvp_status` opens at `achieved` rather than `defining`.

--- a/project/mission.md
+++ b/project/mission.md
@@ -18,62 +18,63 @@ revised_at: null
 
 `gh-plumbing` gives downstream `nolte/*` repositories one centralised, tag-pinned
 source of reusable GitHub Actions workflows, `Probot` governance commons, and
-`Renovate` presets, so they achieve consistent CI/CD and repository governance
+`Renovate` presets. They achieve consistent CI/CD and repository governance
 without duplicating or copy-pasting pipeline and configuration boilerplate.
 
-- **Specific**: the statement names *what* (reusable workflows plus `Probot`
-  commons plus `Renovate` presets, published by reference) and *for whom* (the
-  downstream consumer audiences plus the maintainer, resolved in `audiences`).
-- **Measurable**: `verifies_via: F-1:acceptance-1`. The mission is measurably met
-  when a downstream repository pins a `reusable-*.yaml` workflow at a tag and its
-  pipeline runs green (F-1's acceptance criterion 1).
-- **Achievable**: the MVP is the three already-shipped capabilities
-  (`reusable-github-actions-workflows`, `probot-commons-config`,
-  `renovate-shared-presets`); roadmap items R-1 through R-3 are `mvp: true`,
-  `detail: fine`, `target_sprint: 1`.
-- **Relevant**: `relevant_outcomes: [O-1, O-2, O-3, O-4]`, each resolving to an
-  outcome in `project/goals.md`.
+- **Specific**: the statement names *what* (reusable workflows, `Probot` commons,
+  and `Renovate` presets, published by reference) and *for whom* (the downstream
+  consumer audiences plus the maintainer, resolved in `audiences`).
+- **Measurable**: `verifies_via: F-1:acceptance-1`. F-1's acceptance criterion 1
+  measures the mission. A downstream repository pins a `reusable-*.yaml` workflow
+  at a tag and its pipeline runs green.
+- **Achievable**: the minimum viable product is the three already-shipped
+  capabilities (`reusable-github-actions-workflows`, `probot-commons-config`,
+  `renovate-shared-presets`). Roadmap items R-1 through R-3 carry `mvp: true`,
+  `detail: fine`, and `target_sprint: 1`.
+- **Relevant**: `relevant_outcomes: [O-1, O-2, O-3, O-4]`. Each entry resolves to
+  an outcome in `project/goals.md`.
 - **Time-bound**: `time_bound: { kind: mvp_completion }`. The bound is the moment
-  the shipped-capability MVP is recorded as achieved, not a calendar date.
+  the shipped minimum viable product reaches achieved status, not a calendar
+  date.
 
 ## Audiences
 
-- **Downstream repositories consuming reusable workflows**: the MVP delivers a
-  library of `reusable-*.yaml` workflows callable via
-  `uses: nolte/gh-plumbing/.github/workflows/reusable-<name>.yaml@<tag>`, so a
-  consumer gets `pre-commit`, `mkdocs`, `Vale`, `automerge`, release-drafter and
-  publish, Docker, Ansible, Terraform, `Trivy`, and coverage pipelines without
-  writing its own.
-- **Downstream repositories extending Probot configurations**: the MVP delivers
-  `.github/commons-*.yml` presets (settings, boring-cyborg, release-drafter,
-  stale) that a consumer inherits via `_extends:`, so labels, branch protection,
-  and housekeeping stay uniform across the portfolio from one source.
-- **Downstream repositories consuming Renovate presets**: the MVP delivers
-  `renovate-configs/common` that a consumer extends via
+- **Downstream repositories consuming reusable workflows**: the minimum viable
+  product delivers a library of `reusable-*.yaml` workflows callable via
+  `uses: nolte/gh-plumbing/.github/workflows/reusable-<name>.yaml@<tag>`. A
+  consumer gets `pre-commit`, `mkdocs`, `Vale`, `automerge`, release, Docker,
+  Ansible, Terraform, `Trivy`, and coverage pipelines without writing its own.
+- **Downstream repositories extending Probot configurations**: the minimum viable
+  product delivers `.github/commons-*.yml` presets (settings, boring-cyborg,
+  release-drafter, stale). A consumer inherits them via `_extends:`, so labels,
+  branch protection, and housekeeping stay uniform across the portfolio.
+- **Downstream repositories consuming Renovate presets**: the minimum viable
+  product delivers `renovate-configs/common`. A consumer extends it via
   `extends: ["github>nolte/gh-plumbing//renovate-configs/common"]`, so
   dependency-update grouping, scheduling, and labelling behave consistently.
-- **Repository maintainer (`nolte`)**: the MVP delivers a single place to evolve
-  the shared surface, with tag-immutable releases and green CI so downstream pins
-  remain stable when the surface changes.
+- **Repository maintainer (`nolte`)**: the minimum viable product delivers a
+  single place to evolve the shared surface. Tag-immutable releases and green CI
+  keep downstream pins stable when the surface changes.
 
 ## Verification
 
-The mission is verified by feature **F-1: Reusable-workflow adoption**, acceptance
-criterion 1: *"A downstream `nolte/*` repository references a `reusable-*.yaml`
-workflow at a published tag and its pipeline run completes green."* This is the
-`verifies_sprint_value` criterion for sprint 0001; it already holds across the
-portfolio (every `automerge`, docs, and spelling run in the sibling repositories
-routes through these workflows), so the shipped-capability MVP is recorded as
-`achieved`.
+Feature **F-1: Reusable-workflow adoption** verifies the mission through
+acceptance criterion 1: *"A downstream `nolte/*` repository references a
+`reusable-*.yaml` workflow at a published tag and its pipeline run completes
+green."* This is the `verifies_sprint_value` criterion for sprint 0001. It
+already holds across the portfolio, because every `automerge`, docs, and
+spelling run in the sibling repositories routes through these workflows. The
+mission therefore records the shipped minimum viable product as `achieved`.
 
 ## Source
 
-- **Audience artefact**: `AUDIENCES.md` at the `gh-plumbing` repository root
-  (consulted at its current develop HEAD); the four `audiences` entries are the
+- **Audience artefact**: `AUDIENCES.md` at the `gh-plumbing` repository root,
+  consulted at its current develop tip. The four `audiences` entries are the
   primary D1, D2, and D3 direct-consumer audiences plus the maintainer.
 - **Outcomes referenced**: O-1, O-2, O-3, O-4 from `project/goals.md`.
 - **Authored by**: the `mission-define` cascade (issue nolte/claude-shared#262
-  mission-authoring backfill), 2026-07-02. The MVP is modelled retroactively:
-  `gh-plumbing`'s three capabilities were already `status: active` when the
-  planning suite was adopted, so R-1 through R-3 are recorded as `status: done`
-  and `mvp_status` opens at `achieved` rather than `defining`.
+  mission-authoring backfill), 2026-07-02. The cascade models the minimum viable
+  product retroactively. `gh-plumbing`'s three capabilities already carried
+  `status: active` when the repository adopted the planning suite, so the roadmap
+  records R-1 through R-3 as `status: done` and opens `mvp_status` at `achieved`
+  rather than `defining`.

--- a/project/mission.md
+++ b/project/mission.md
@@ -5,7 +5,7 @@ audiences:
   - Downstream repositories consuming reusable workflows
   - Downstream repositories extending Probot configurations
   - Downstream repositories consuming Renovate presets
-  - Repository maintainer (nolte)
+  - Repository maintainer (`nolte`)
 verifies_via: F-1:acceptance-1
 time_bound:
   kind: mvp_completion

--- a/project/roadmap.md
+++ b/project/roadmap.md
@@ -1,0 +1,72 @@
+# Roadmap
+
+This file is the work queue governed by `spec/project/roadmap/`. Each entry is a
+level-3 heading followed by a `yaml` code block (`id`, `title`, `detail`,
+`outcomes`, `target_sprint`, `mvp`, `status` — in that order) and a free-text
+body. Detail level (`detail`: `fine` / `coarse` / `backlog`) and the status
+lifecycle (`status`: `proposed` → `active` → `done`, plus `cancelled`) are
+enforced by `roadmap-plan` and `roadmap-refine`, not hand-edited here.
+
+Entries carry monotonically increasing IDs `R-1`, `R-2`, …, never reused.
+Outcome IDs (`O-n` in `goals.md`) are an independent counter — the streams never
+cross.
+
+The three MVP items below were **delivered before** the planning suite was
+adopted (gh-plumbing is a mature, portfolio-wide configuration source); they are
+recorded here retroactively as `status: done`, mapped to sprint 1, so the mission
+MVP resolves. See `project/mission.md` §Source.
+
+## Phase 1 — Shared CI/CD & governance baseline
+
+### R-1 — Reusable GitHub Actions workflow library
+
+```yaml
+id: R-1
+title: Reusable GitHub Actions workflow library
+detail: fine
+outcomes: [O-1]
+target_sprint: 1
+mvp: true
+status: done
+```
+
+The `reusable-*.yaml` workflow library (pre-commit, MkDocs build/deploy,
+spelling/Vale, automerge, release-drafter/publish, Docker lint/build/publish,
+Ansible molecule/galaxy, Terraform lint, Trivy, chain-bench, dependency-review,
+Node.js/Python coverage) that downstream `nolte/*` repositories call via
+`uses: nolte/gh-plumbing/.github/workflows/reusable-<name>.yaml@<tag>`.
+Capability `reusable-github-actions-workflows` in `project/portfolio.yml`.
+
+### R-2 — Probot configuration commons
+
+```yaml
+id: R-2
+title: Probot configuration commons
+detail: fine
+outcomes: [O-2]
+target_sprint: 1
+mvp: true
+status: done
+```
+
+The shared `.github/commons-*.yml` Probot presets (settings, boring-cyborg,
+release-drafter, stale) that downstream repositories inherit via `_extends:` so
+labels, branch protection, and housekeeping stay uniform across the portfolio.
+Capability `probot-commons-config` in `project/portfolio.yml`.
+
+### R-3 — Renovate shared presets
+
+```yaml
+id: R-3
+title: Renovate shared presets
+detail: fine
+outcomes: [O-3]
+target_sprint: 1
+mvp: true
+status: done
+```
+
+The `renovate-configs/common` preset that downstream repositories extend via
+`extends: ["github>nolte/gh-plumbing//renovate-configs/common"]` for consistent
+dependency-update grouping, scheduling, and labelling. Capability
+`renovate-shared-presets` in `project/portfolio.yml`.

--- a/project/roadmap.md
+++ b/project/roadmap.md
@@ -2,23 +2,23 @@
 
 This file is the work queue governed by `spec/project/roadmap/`. Each entry is a
 level-3 heading followed by a `yaml` code block (`id`, `title`, `detail`,
-`outcomes`, `target_sprint`, `mvp`, `status` — in that order) and a free-text
+`outcomes`, `target_sprint`, `mvp`, `status`, in that order) and a free-text
 body. Detail level (`detail`: `fine` / `coarse` / `backlog`) and the status
-lifecycle (`status`: `proposed` → `active` → `done`, plus `cancelled`) are
-enforced by `roadmap-plan` and `roadmap-refine`, not hand-edited here.
+lifecycle (`status`: `proposed`, `active`, `done`, plus `cancelled`) are enforced
+by `roadmap-plan` and `roadmap-refine`, not hand-edited here.
 
-Entries carry monotonically increasing IDs `R-1`, `R-2`, …, never reused.
-Outcome IDs (`O-n` in `goals.md`) are an independent counter — the streams never
+Entries carry monotonically increasing IDs starting at `R-1`, never reused.
+Outcome IDs (`O-n` in `goals.md`) are an independent counter; the streams never
 cross.
 
 The three MVP items below were **delivered before** the planning suite was
-adopted (gh-plumbing is a mature, portfolio-wide configuration source); they are
-recorded here retroactively as `status: done`, mapped to sprint 1, so the mission
-MVP resolves. See `project/mission.md` §Source.
+adopted, because `gh-plumbing` is a mature, portfolio-wide configuration source.
+They're recorded here retroactively as `status: done`, mapped to sprint 1, so the
+mission MVP resolves. See `project/mission.md` §Source.
 
-## Phase 1 — Shared CI/CD & governance baseline
+## Phase 1: Shared CI/CD and governance baseline
 
-### R-1 — Reusable GitHub Actions workflow library
+### R-1: Reusable GitHub Actions workflow library
 
 ```yaml
 id: R-1
@@ -30,14 +30,15 @@ mvp: true
 status: done
 ```
 
-The `reusable-*.yaml` workflow library (pre-commit, MkDocs build/deploy,
-spelling/Vale, automerge, release-drafter/publish, Docker lint/build/publish,
-Ansible molecule/galaxy, Terraform lint, Trivy, chain-bench, dependency-review,
-Node.js/Python coverage) that downstream `nolte/*` repositories call via
+The `reusable-*.yaml` workflow library (`pre-commit`, `mkdocs` build and deploy,
+spelling and `Vale`, `automerge`, release-drafter and publish, Docker lint,
+build, and publish, Ansible molecule and galaxy, Terraform lint, `Trivy`,
+chain-bench, dependency-review, Node.js and Python coverage) that downstream
+`nolte/*` repositories call via
 `uses: nolte/gh-plumbing/.github/workflows/reusable-<name>.yaml@<tag>`.
 Capability `reusable-github-actions-workflows` in `project/portfolio.yml`.
 
-### R-2 — Probot configuration commons
+### R-2: Probot configuration commons
 
 ```yaml
 id: R-2
@@ -49,12 +50,12 @@ mvp: true
 status: done
 ```
 
-The shared `.github/commons-*.yml` Probot presets (settings, boring-cyborg,
+The shared `.github/commons-*.yml` `Probot` presets (settings, boring-cyborg,
 release-drafter, stale) that downstream repositories inherit via `_extends:` so
 labels, branch protection, and housekeeping stay uniform across the portfolio.
 Capability `probot-commons-config` in `project/portfolio.yml`.
 
-### R-3 — Renovate shared presets
+### R-3: Renovate shared presets
 
 ```yaml
 id: R-3

--- a/project/roadmap.md
+++ b/project/roadmap.md
@@ -16,7 +16,7 @@ adopted, because `gh-plumbing` is a mature, portfolio-wide configuration source.
 They're recorded here retroactively as `status: done`, mapped to sprint 1, so the
 mission MVP resolves. See `project/mission.md` §Source.
 
-## Phase 1: Shared CI/CD and governance baseline
+## Phase 1: Shared delivery and governance baseline
 
 ### R-1: Reusable GitHub Actions workflow library
 

--- a/project/roadmap.md
+++ b/project/roadmap.md
@@ -3,22 +3,23 @@
 This file is the work queue governed by `spec/project/roadmap/`. Each entry is a
 level-3 heading followed by a `yaml` code block (`id`, `title`, `detail`,
 `outcomes`, `target_sprint`, `mvp`, `status`, in that order) and a free-text
-body. Detail level (`detail`: `fine` / `coarse` / `backlog`) and the status
-lifecycle (`status`: `proposed`, `active`, `done`, plus `cancelled`) are enforced
-by `roadmap-plan` and `roadmap-refine`, not hand-edited here.
+body. `roadmap-plan` and `roadmap-refine` own the detail level (`detail`: `fine`
+/ `coarse` / `backlog`) and the status lifecycle (`status`: `proposed`,
+`active`, `done`, plus `cancelled`). Don't hand-edit those fields here.
 
 Entries carry monotonically increasing IDs starting at `R-1`, never reused.
-Outcome IDs (`O-n` in `goals.md`) are an independent counter; the streams never
-cross.
+Outcome IDs (`O-n` in `goals.md`) are an independent counter. The two streams
+never cross.
 
-The three MVP items below were **delivered before** the planning suite was
-adopted, because `gh-plumbing` is a mature, portfolio-wide configuration source.
-They're recorded here retroactively as `status: done`, mapped to sprint 1, so the
-mission MVP resolves. See `project/mission.md` §Source.
+`gh-plumbing` shipped the three minimum-viable-product items below before
+adopting the planning suite, because it's a mature, portfolio-wide
+configuration source. This roadmap records them retroactively as `status: done`,
+mapped to sprint 1, so the mission's minimum viable product resolves. See
+`project/mission.md` §Source.
 
 ## Phase 1: Shared delivery and governance baseline
 
-### R-1: Reusable GitHub Actions workflow library
+### R-1: Reusable workflow library
 
 ```yaml
 id: R-1
@@ -30,11 +31,10 @@ mvp: true
 status: done
 ```
 
-The `reusable-*.yaml` workflow library (`pre-commit`, `mkdocs` build and deploy,
-spelling and `Vale`, `automerge`, release-drafter and publish, Docker lint,
-build, and publish, Ansible molecule and galaxy, Terraform lint, `Trivy`,
-chain-bench, dependency-review, Node.js and Python coverage) that downstream
-`nolte/*` repositories call via
+The `reusable-*.yaml` workflow library covers linting, docs, spelling, test
+coverage, container build and publish, Ansible and Terraform checks, release
+automation, and security scanning. The README §Workflows lists the full
+catalogue. Downstream `nolte/*` repositories call it via
 `uses: nolte/gh-plumbing/.github/workflows/reusable-<name>.yaml@<tag>`.
 Capability `reusable-github-actions-workflows` in `project/portfolio.yml`.
 
@@ -50,10 +50,10 @@ mvp: true
 status: done
 ```
 
-The shared `.github/commons-*.yml` `Probot` presets (settings, boring-cyborg,
-release-drafter, stale) that downstream repositories inherit via `_extends:` so
-labels, branch protection, and housekeeping stay uniform across the portfolio.
-Capability `probot-commons-config` in `project/portfolio.yml`.
+The `Probot` presets cover four areas: settings, boring-cyborg, release-drafter,
+and stale. A downstream repository inherits them by extending the shared commons
+file. Governance stays uniform across the portfolio. Capability
+`probot-commons-config` in `project/portfolio.yml`.
 
 ### R-3: Renovate shared presets
 
@@ -67,7 +67,7 @@ mvp: true
 status: done
 ```
 
-The `renovate-configs/common` preset that downstream repositories extend via
-`extends: ["github>nolte/gh-plumbing//renovate-configs/common"]` for consistent
-dependency-update grouping, scheduling, and labelling. Capability
+The `renovate-configs/common` preset. Downstream repositories extend it via
+`extends: ["github>nolte/gh-plumbing//renovate-configs/common"]`. It gives
+consistent dependency-update grouping, scheduling, and labelling. Capability
 `renovate-shared-presets` in `project/portfolio.yml`.

--- a/project/sprints/0001-shared-cicd-baseline.md
+++ b/project/sprints/0001-shared-cicd-baseline.md
@@ -1,0 +1,44 @@
+---
+number: 1
+status: closed
+started: 2026-07-02
+ended: 2026-07-02
+value_statement: Downstream nolte/* repositories consume gh-plumbing's reusable workflows, Probot commons, and Renovate presets by reference and get consistent CI/CD and governance without reimplementing boilerplate.
+artifact_ref: develop (shipped capabilities, pre-planning-suite)
+roadmap_items: [R-1, R-2, R-3]
+features: [F-1]
+---
+
+## Goal
+
+Downstream `nolte/*` repositories obtain consistent CI/CD and repository
+governance from one centralised, tag-pinned source — reusable GitHub Actions
+workflows, Probot configuration commons, and Renovate presets — rather than
+copy-pasting pipeline and configuration boilerplate. Success is verified by F-1
+`acceptance-1`: a downstream repository references a `reusable-*.yaml` workflow
+at a published tag and its pipeline run completes green.
+
+## Features
+
+- [F-1](../features/reusable-workflow-adoption.md) — Reusable-workflow adoption — status: done
+
+## Out of scope
+
+- Codifying per-workflow input/secret stability contracts and a deprecation
+  policy (tracked as an open question in `AUDIENCES.md`; not part of the shipped
+  MVP).
+- The repository's own dog-fooding wrapper workflows (`build-static-tests.yaml`,
+  `release-cd-refresh-master.yml`, `automerge.yaml`, …), which consume the
+  reusable workflows but sit outside the published bounded context.
+
+## Review notes
+
+Retroactive reconciliation (2026-07-02): gh-plumbing's three capabilities
+(`reusable-github-actions-workflows`, `probot-commons-config`,
+`renovate-shared-presets`) were already `status: active` and consumed
+portfolio-wide before this repository adopted the planning suite (issue
+nolte/claude-shared#262 mission-authoring backfill). Roadmap items R-1..R-3 and
+feature F-1 are therefore recorded as `done`, and this sprint as `closed`, to
+document the delivered MVP rather than to plan new work. The value verifier F-1
+`acceptance-1` already holds — every automerge/docs/spelling run in the sibling
+nolte repositories routes through these reusable workflows.

--- a/project/sprints/0001-shared-cicd-baseline.md
+++ b/project/sprints/0001-shared-cicd-baseline.md
@@ -12,11 +12,12 @@ features: [F-1]
 ## Goal
 
 Downstream `nolte/*` repositories obtain consistent CI/CD and repository
-governance from one centralised, tag-pinned source (reusable GitHub Actions
-workflows, `Probot` configuration commons, and `Renovate` presets) rather than
-copy-pasting pipeline and configuration boilerplate. Success is verified by F-1
-`acceptance-1`: a downstream repository references a `reusable-*.yaml` workflow at
-a published tag and its pipeline run completes green.
+governance from one centralised, tag-pinned source. That source covers reusable
+GitHub Actions workflows, `Probot` configuration commons, and `Renovate` presets.
+The consumer no longer copy-pastes pipeline and configuration boilerplate. F-1
+`acceptance-1` verifies success: a downstream repository references a
+`reusable-*.yaml` workflow at a published tag and its pipeline run completes
+green.
 
 ## Features
 
@@ -25,20 +26,21 @@ a published tag and its pipeline run completes green.
 ## Out of scope
 
 - Codifying per-workflow input and secret stability contracts and a deprecation
-  policy (tracked as an open question in `AUDIENCES.md`; not part of the shipped
-  MVP).
+  policy. `AUDIENCES.md` tracks this as an open question, outside the shipped
+  scope.
 - The repository's own dog-fooding wrapper workflows (`build-static-tests.yaml`,
-  `release-cd-refresh-master.yml`, `automerge.yaml`, and the like), which consume
+  `release-cd-refresh-master.yml`, `automerge.yaml`, and the like). They consume
   the reusable workflows but sit outside the published bounded context.
 
 ## Review notes
 
 Retroactive reconciliation (2026-07-02): `gh-plumbing`'s three capabilities
 (`reusable-github-actions-workflows`, `probot-commons-config`,
-`renovate-shared-presets`) were already `status: active` and consumed
-portfolio-wide before this repository adopted the planning suite (issue
-nolte/claude-shared#262 mission-authoring backfill). Roadmap items R-1 through R-3
-and feature F-1 are therefore recorded as `done`, and this sprint as `closed`, to
-document the delivered MVP rather than to plan new work. The value verifier F-1
-`acceptance-1` already holds: every `automerge`, docs, and spelling run in the
-sibling `nolte` repositories routes through these reusable workflows.
+`renovate-shared-presets`) already carried `status: active` and served the
+portfolio before this repository adopted the planning suite (issue
+nolte/claude-shared#262 mission-authoring backfill). This sprint therefore
+records roadmap items R-1 through R-3 and feature F-1 as `done`, and itself as
+`closed`. That documents the delivered minimum viable product rather than new
+planned work. The value verifier F-1 `acceptance-1` already holds: every `automerge`,
+docs, and spelling run in the sibling `nolte` repositories routes through these
+reusable workflows.

--- a/project/sprints/0001-shared-cicd-baseline.md
+++ b/project/sprints/0001-shared-cicd-baseline.md
@@ -3,7 +3,7 @@ number: 1
 status: closed
 started: 2026-07-02
 ended: 2026-07-02
-value_statement: Downstream nolte/* repositories consume gh-plumbing's reusable workflows, Probot commons, and Renovate presets by reference and get consistent CI/CD and governance without reimplementing boilerplate.
+value_statement: Downstream nolte/* repositories consume gh-plumbing's reusable workflows, Probot commons, and Renovate presets by reference and get consistent CI/CD and governance without duplicating boilerplate.
 artifact_ref: develop (shipped capabilities, pre-planning-suite)
 roadmap_items: [R-1, R-2, R-3]
 features: [F-1]
@@ -12,33 +12,33 @@ features: [F-1]
 ## Goal
 
 Downstream `nolte/*` repositories obtain consistent CI/CD and repository
-governance from one centralised, tag-pinned source — reusable GitHub Actions
-workflows, Probot configuration commons, and Renovate presets — rather than
+governance from one centralised, tag-pinned source (reusable GitHub Actions
+workflows, `Probot` configuration commons, and `Renovate` presets) rather than
 copy-pasting pipeline and configuration boilerplate. Success is verified by F-1
-`acceptance-1`: a downstream repository references a `reusable-*.yaml` workflow
-at a published tag and its pipeline run completes green.
+`acceptance-1`: a downstream repository references a `reusable-*.yaml` workflow at
+a published tag and its pipeline run completes green.
 
 ## Features
 
-- [F-1](../features/reusable-workflow-adoption.md) — Reusable-workflow adoption — status: done
+- [F-1](../features/reusable-workflow-adoption.md): Reusable-workflow adoption, status: done
 
 ## Out of scope
 
-- Codifying per-workflow input/secret stability contracts and a deprecation
+- Codifying per-workflow input and secret stability contracts and a deprecation
   policy (tracked as an open question in `AUDIENCES.md`; not part of the shipped
   MVP).
 - The repository's own dog-fooding wrapper workflows (`build-static-tests.yaml`,
-  `release-cd-refresh-master.yml`, `automerge.yaml`, …), which consume the
-  reusable workflows but sit outside the published bounded context.
+  `release-cd-refresh-master.yml`, `automerge.yaml`, and the like), which consume
+  the reusable workflows but sit outside the published bounded context.
 
 ## Review notes
 
-Retroactive reconciliation (2026-07-02): gh-plumbing's three capabilities
+Retroactive reconciliation (2026-07-02): `gh-plumbing`'s three capabilities
 (`reusable-github-actions-workflows`, `probot-commons-config`,
 `renovate-shared-presets`) were already `status: active` and consumed
 portfolio-wide before this repository adopted the planning suite (issue
-nolte/claude-shared#262 mission-authoring backfill). Roadmap items R-1..R-3 and
-feature F-1 are therefore recorded as `done`, and this sprint as `closed`, to
+nolte/claude-shared#262 mission-authoring backfill). Roadmap items R-1 through R-3
+and feature F-1 are therefore recorded as `done`, and this sprint as `closed`, to
 document the delivered MVP rather than to plan new work. The value verifier F-1
-`acceptance-1` already holds — every automerge/docs/spelling run in the sibling
-nolte repositories routes through these reusable workflows.
+`acceptance-1` already holds: every `automerge`, docs, and spelling run in the
+sibling `nolte` repositories routes through these reusable workflows.

--- a/terraform/portfolio-app/README.md
+++ b/terraform/portfolio-app/README.md
@@ -67,14 +67,14 @@ the configuration sets both or neither.
 Before `terraform apply`:
 
 1. The portfolio App carries the permissions listed in
-   `docs/en/portfolio-app/setup.md` §Permissions the app requires —
+   `docs/en/portfolio-app/setup.md` §Permissions the app requires:
    `Contents: Read and write`, `Pull requests: Read and write`,
    `Issues: Read and write`, `Actions: Read-only`, plus the implicit
    `Metadata: Read-only` baseline. `Issues: Read and write` is what
-   lets an App-driven squash-merge auto-close issues referenced via
-   `Closes #N` in the PR body; without it the merge succeeds but the
+   lets an App-driven squash-merge automatically close issues referenced
+   via `Closes #N` in the PR body; without it the merge succeeds but the
    issue stays `OPEN`. The Terraform module doesn't manage App
-   permissions — they're set on the App's registration page in the
+   permissions; they're set on the App's registration page in the
    GitHub UI.
 2. The App lives in every repository you intend to list under
    `consumer_repositories`.


### PR DESCRIPTION
## Summary

Authors the `project/` planning suite for gh-plumbing so it ships a valid `project/mission.md`, closing the mission-authoring half of the portfolio backfill tracked in nolte/claude-shared#262 (gh-plumbing is one of the two prioritised W2 repos). The manifest (`project/portfolio.yml`) already exists; this PR adds the missing planning artefacts the mission spec (`spec/project/mission/`) requires as hard preconditions.

Because gh-plumbing is a **mature, portfolio-wide configuration source** whose three capabilities were already `status: active` before the planning suite was adopted, the MVP is modelled **retroactively**: roadmap items and the sprint/feature are recorded as `done`/`closed` to document the delivered surface, and `mvp_status` opens at `achieved`. This mirrors the retroactive-reconciliation pattern already used in nolte/kamerplanter's sprint 0001.

## Changes

- `project/goals.md` — Vision (from the README intro) + four Outcomes (O-1..O-4) derived 1:1 from the three `portfolio.yml` capabilities plus the maintainer audience.
- `project/roadmap.md` — R-1..R-3 (reusable workflows / Probot commons / Renovate presets), each `mvp: true`, `detail: fine`, `target_sprint: 1`, `status: done`.
- `project/sprints/0001-shared-cicd-baseline.md` — retroactive sprint 1 (`status: closed`) with the consumer-facing `value_statement`.
- `project/features/reusable-workflow-adoption.md` — F-1, the mission-verifying feature (`verifies_sprint_value: acceptance-1`).
- `project/mission.md` — SMART mission with the eight required frontmatter fields, the four required sections, a per-audience paragraph for each of the four audiences, and `verifies_via: F-1:acceptance-1`.

All content is grounded in existing repo artefacts (`README.md`, `project/portfolio.yml`, `AUDIENCES.md`) — no invented audiences or missions, per the nolte/claude-shared#262 constraint.

## Linked issues

Part of nolte/claude-shared#262 (mission-authoring backfill).

## Testing

Structural conformance authored against `spec/project/mission/`, `spec/project/roadmap/`, `spec/project/sprint/`, and `spec/project/feature/`; the frontmatter field order, section order, audience↔paragraph bidirectionality, and `verifies_via` → feature/acceptance resolution were checked by hand against the specs. No CI planning-suite validator runs in this repo.

## Risk / rollout notes

Additive `project/` documentation only; no workflow, config, or published-surface change. Opened as **draft** for review of the retroactive-MVP modelling before it is applied as the template for the remaining nolte/claude-shared#262 repos. Trivially reversible (delete the five files).
