### PR TITLE
feat(labels): add frontend, backend, test, security labels

### DIFF
--- a/.github/commons-boring-cyborg.yml
+++ b/.github/commons-boring-cyborg.yml
@@ -14,4 +14,10 @@ labelPRBasedOnFilePath:
     - .github/pull_request_template.md
   spec:
     - spec/**
+  frontend:
+    - src/frontend/**
+    - frontend/**
+  backend:
+    - src/backend/**
+    - backend/**
 # <!--td-commons-settings-labels-end-->

--- a/.github/commons-settings.yml
+++ b/.github/commons-settings.yml
@@ -78,6 +78,22 @@ labels:
     color: "#caa7e8"
     description: Update documentation.
 
+  - name: frontend
+    color: "#d876e3"
+    description: Touches frontend / UI code (`src/frontend/**`).
+
+  - name: backend
+    color: "#0e8a16"
+    description: Touches backend / server-side code (`src/backend/**`).
+
+  - name: test
+    color: "#f9d0c4"
+    description: Touches automated tests.
+
+  - name: security
+    color: "#d93f0b"
+    description: Security-relevant change or fix.
+
   - name: cicd
     color: "#fbca04"
     description: ci/cd process functionality.

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -7,7 +7,11 @@
 # file as well (a comment touch is enough) so the App re-runs the merge.
 # Tracked by https://github.com/nolte/gh-plumbing/issues/331.
 #
-# Last propagation: 2026-06-14 — declare this repo's own required status
+# Last propagation: 2026-07-22 — propagate new commons labels (frontend,
+# backend, test, security) added to commons-settings.yml so the Settings
+# App re-runs the `_extends` merge and creates them portfolio-wide.
+#
+# Previous propagation: 2026-06-14 — declare this repo's own required status
 # checks on develop. commons-settings.yml leaves develop's
 # `required_status_checks.contexts` empty by portfolio policy ("Consumers
 # MUST declare their own required-check contexts in their per-repo


### PR DESCRIPTION
## Summary

Extend the portfolio-wide commons label set with four labels that consumer repos (notably kamerplanter) already apply ad-hoc but were never centrally defined, and wire path-based auto-labeling for `frontend` / `backend`.

## Changes

- Add `frontend`, `backend`, `test`, and `security` label definitions to `commons-settings.yml`.
- Add boring-cyborg path rules so `src/frontend/**` / `frontend/**` → `frontend` and `src/backend/**` / `backend/**` → `backend` are auto-applied on PRs.
- Bump the propagation-trigger comment in `settings.yml` so the Probot Settings App re-runs the `_extends` merge and creates the labels portfolio-wide.

## Linked issues

None

## Testing

- `pre-commit run --files .github/commons-settings.yml .github/commons-boring-cyborg.yml .github/settings.yml` — all hooks pass, including the label-description ≤100-char check.
- Verified no duplicate label `name:` keys and valid YAML across all three files.

## Risk / rollout notes

Low. Config-only change to public shared config; propagates to every consumer via Probot `_extends`. New labels are additive — existing labels and branch-protection blocks are untouched. `boring-cyborg` resolves `_extends` per PR at runtime, so auto-labeling is live once merged; the Settings App re-sync creates the label definitions.