### PR TITLE
fix(workflows): add concurrency groups to the delivery workflows

### DIFF
--- a/.github/workflows/build-static-tests.yaml
+++ b/.github/workflows/build-static-tests.yaml
@@ -4,6 +4,19 @@ on:
   push:
   workflow_dispatch:
 
+# Pre-merge feedback, so cancel-in-progress is true: a superseded run on the
+# same ref has nothing left to tell us and only delays the run that matters.
+# This is the §F SHOULD, not the MUST -- the four jobs below are read-only and
+# would not corrupt anything by overlapping, they would merely waste a runner.
+#
+# This block lives in the wrapper rather than in the four reusables it calls.
+# Putting it in each reusable would give all four the same group and serialise
+# them against each other, turning a parallel fan-out into a queue. Consumers
+# copying this wrapper should carry the block with it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   static:
     uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@develop

--- a/.github/workflows/reusable-mkdocs.yaml
+++ b/.github/workflows/reusable-mkdocs.yaml
@@ -51,6 +51,17 @@ on:
           Required when `app-id` is set; ignored otherwise.
         required: false
 
+# The deploy pushes to gh-pages, so concurrent runs race on one branch
+# regardless of which ref triggered them -- hence a static group rather than a
+# ref-derived one.
+#
+# cancel-in-progress stays false per spec/project/github-actions-best-practices
+# §F: cancelling a half-finished gh-pages push is worse than queueing behind it.
+concurrency:
+  group: mkdocs-deploy
+  cancel-in-progress: false
+
+
 jobs:
   publish_docs:
     name: "Publish the HTML Documentation"

--- a/.github/workflows/reusable-release-cd-refresh-master.yml
+++ b/.github/workflows/reusable-release-cd-refresh-master.yml
@@ -34,6 +34,20 @@ on:
           Required when `app-id` is set; ignored otherwise.
         required: false
 
+# Every run of this workflow updates the same presentation branch, so two
+# releases published close together race on one target. The group is static
+# rather than ref-derived on purpose: the contended resource is the target
+# branch, not the ref that triggered the run, and two runs from different tags
+# still collide. Matches the `release-publish` group in
+# reusable-release-publish.yml.
+#
+# cancel-in-progress stays false per spec/project/github-actions-best-practices
+# §F: a delivery workflow must never cancel an in-flight run.
+concurrency:
+  group: release-cd-refresh-master
+  cancel-in-progress: false
+
+
 jobs:
   refresh_presentation_branch:
     name: "Publish the the Release to Master"

--- a/.github/workflows/reusable-release-drafter.yml
+++ b/.github/workflows/reusable-release-drafter.yml
@@ -27,6 +27,20 @@ on:
           Required when `app-id` is set; ignored otherwise.
         required: false
 
+# release-drafter rewrites the whole draft body, so this reusable brackets the
+# call with a capture/restore of the project-context block (see the `jobs:`
+# below). That read-modify-write is not atomic: two pushes to develop in quick
+# succession would interleave and one run would overwrite the other's restored
+# block, silently shipping release notes with a section missing. Serialise per
+# ref so the sequence runs to completion.
+#
+# cancel-in-progress stays false: cancelling mid-sequence is what would leave
+# the draft body in the half-written state this group exists to prevent.
+concurrency:
+  group: release-drafter-${{ github.ref }}
+  cancel-in-progress: false
+
+
 jobs:
   update_release_draft:
     name: Update Release Draft


### PR DESCRIPTION
## Summary

Exactly one workflow in the repository declared `concurrency` before this change. This adds it to the three that can corrupt state by overlapping, plus the pre-merge workflow where it saves runner time.

Closes #391

## Changes

| File | Group | `cancel-in-progress` | Why |
|---|---|---|---|
| `reusable-release-drafter.yml` | `release-drafter-${{ github.ref }}` | `false` | Brackets release-drafter with a capture/restore of the `project-context` block. That read-modify-write is not atomic, so two pushes to `develop` in quick succession interleave and one silently loses its block. |
| `reusable-release-cd-refresh-master.yml` | `release-cd-refresh-master` | `false` | Every run updates the same presentation branch; two releases published close together race on one target. |
| `reusable-mkdocs.yaml` | `mkdocs-deploy` | `false` | Same shape on the `gh-pages` push. |
| `build-static-tests.yaml` | `${{ github.workflow }}-${{ github.ref }}` | `true` | Pre-merge feedback — a superseded run has nothing left to say. |

Two placement decisions worth stating, because both could reasonably have gone the other way:

**The three delivery groups live in the reusables, not the wrappers.** This is the shared library, so a fix in the reusable reaches every consumer; a fix in the wrapper reaches only this repository. It follows the existing `release-publish` block in `reusable-release-publish.yml`.

**Two groups are static rather than ref-derived.** For `refresh-master` and `mkdocs-deploy` the contended resource is the *target* branch (`master`, `gh-pages`), not the ref that triggered the run — two runs from different tags still collide on it, so a ref-derived group would not serialise them. `release-drafter` is ref-derived because the draft it rewrites is per-branch.

**The `build-static-tests.yaml` block stays in the wrapper.** Putting it in each of the four reusables it calls would give all four the same group and serialise them against each other, turning a parallel fan-out into a queue. Consumers copying this wrapper should carry the block with it.

## Linked issues

Closes #391

## Testing

- `pre-commit run --all-files` — green.
- All five `concurrency` blocks parsed back out of the YAML and asserted to carry the intended group and `cancel-in-progress` value.
- `build-static-tests.yaml`'s block is **live on this PR**: the triggering workflow is read from the pushed ref, so its group applies to this run.

**Not verifiable here, stated rather than glossed:** the three reusable-level blocks have no caller in a pull-request context — they fire on `push: develop` and `release: published`. Their runtime behaviour is exercised on the next release. The pattern itself is already proven in this repository: `reusable-release-publish.yml` has carried a workflow-level `concurrency` block through published releases, which is what establishes that `workflow_call` workflows honour it.

## Risk / rollout notes

**Issue:** #391 — release-drafter can lose the project-context block: no concurrency groups on the delivery workflows
**Classification:** `bug` — the release-drafter case is a live lost-update, not a hardening gap.
**Specialist:** `nolte-shared:cicd-pipeline-design` (the finding came from `nolte-shared:cicd-pipeline-reviewer` during the #388 audit).

**Behaviour change for consumers.** The three reusable-level groups reach every consumer on their next `gh-plumbing` bump. Effect: concurrent delivery runs now queue instead of racing. A consumer that publishes two releases within a few minutes will see the second wait rather than fail or corrupt — that is the intent, but it is a scheduling change, not a no-op.

`cancel-in-progress: false` on all three is mandatory per `spec/project/github-actions-best-practices/` §F: a delivery or release workflow must never cancel an in-flight run. Only the pre-merge workflow cancels.

**Rollback:** each block is independent; reverting one file does not affect the others.
