### PR TITLE
fix(release-drafter): resolve the version from labels instead of always patch

### DIFF
--- a/.github/commons-release-drafter.yml
+++ b/.github/commons-release-drafter.yml
@@ -1,18 +1,63 @@
 ---
-name-template: v$NEXT_PATCH_VERSION
-tag-template: v$NEXT_PATCH_VERSION
+# Portfolio-wide release-drafter commons. Every repository extends this via
+# `_extends: gh-plumbing:.github/commons-release-drafter.yml`, so a change here
+# reaches the whole portfolio on the next Probot sync.
+
+# $RESOLVED_VERSION, not $NEXT_PATCH_VERSION. Before the resolver below existed
+# every release was a patch regardless of what landed, so a `breaking-change`
+# label had no effect on the version. That combination is worse than it sounds:
+# consumers pin by tag and update through Renovate, and a patch bump is the
+# update class most likely to be automerged or waved through -- so the change
+# least likely to be scrutinised was the one carrying the break.
+name-template: v$RESOLVED_VERSION
+tag-template: v$RESOLVED_VERSION
+
+version-resolver:
+  major:
+    labels:
+      - breaking-change
+  minor:
+    labels:
+      - feat
+      - enhancement
+  patch:
+    labels:
+      - fix
+      - bug
+      - chore
+      - docs
+      - documentation
+      - project-config
+      - cicd
+      - dependencies
+      - security
+  default: patch
+
 branches:
   - master
   - develop
+
+# The label lists carry both the Conventional-Commits labels the portfolio
+# actually applies (`feat`, `fix`) and the GitHub defaults (`enhancement`,
+# `bug`). Previously the categories matched only the defaults, so a PR labelled
+# `fix` -- the portfolio convention -- fell into the uncategorised remainder of
+# the changelog and never appeared under a heading.
 categories:
   - title: 🚀 Features
-    label: enhancement
+    labels:
+      - "feat"
+      - "enhancement"
   - title: 🐛 Bug Fixes
-    label: bug
+    labels:
+      - "fix"
+      - "bug"
   - title: 🧰 Maintenance
     labels:
       - "chore"
-      - "documentations"
+      # `docs` and `documentation` are the labels that exist; the previous
+      # `documentations` entry matched nothing in any portfolio repository.
+      - "docs"
+      - "documentation"
       - "project-config"
       - "cicd"
       - "dependencies"


### PR DESCRIPTION
## Summary

`commons-release-drafter.yml` had no `version-resolver`, so `name-template: v$NEXT_PATCH_VERSION` made **every** release a patch regardless of what landed. A `breaking-change` label had no effect on the version; neither did a feature.

That combination is worse than it sounds. Consumers pin `gh-plumbing` by tag and update through Renovate, and a patch bump is the update class most likely to be automerged or waved through with minimal review — so the change least likely to be scrutinised was the one carrying the break. The `breaking-change` label existing in the repository made the gap look closed when it was not.

Closes #395

## Changes

**`$RESOLVED_VERSION` replaces `$NEXT_PATCH_VERSION`**, driven by a resolver:

| Bump | Labels |
|---|---|
| major | `breaking-change` |
| minor | `feat`, `enhancement` |
| patch | `fix`, `bug`, `chore`, `docs`, `documentation`, `project-config`, `cicd`, `dependencies`, `security` |
| default | patch |

**The changelog categories now match the labels this portfolio actually applies.** They previously filtered on `enhancement` and `bug` — the GitHub defaults — while the portfolio convention is `feat` and `fix`. A PR labelled `fix` therefore matched no category and landed in the uncategorised remainder. Both spellings are now listed, so nothing that worked before stops working.

The Maintenance category also listed `documentations`, which is not a label in any portfolio repository and never matched anything. Replaced with the labels that exist: `docs` and `documentation`.

## Linked issues

Closes #395

## Testing

`_extends` is resolved by the release-drafter App at run time, so this needs no Probot settings sync — unlike `commons-settings.yml`, it takes effect on the next `push: develop`.

**Verification is post-merge by nature.** The draft is recomputed when release-drafter next runs; correctness shows up as the draft's version changing. Nothing in a pull-request check can exercise this.

## Risk / rollout notes

**Issue:** #395 — commons-release-drafter has no version-resolver: breaking changes ship as patch releases portfolio-wide
**Classification:** `bug` — the version a release carries was wrong, not merely unhelpful.
**Specialist:** no matching specialised agent — generalist remediation. No portfolio specialist covers release-drafter configuration; `release-notes-curate` curates a draft's body, not its versioning.

### The next release becomes v2.0.0

The open draft is currently **v1.1.27**. Once this lands, release-drafter recomputes it as **v2.0.0**, because two merged PRs in this cycle carry `breaking-change`:

- **#397** narrowed `permissions` across all 30 workflows. A consumer relying on the previous permissive default can hit a permission error.
- **#400** pinned the toolchain defaults (`3.x` → `3.14`, `lts/*` → `24`). A consumer whose code needs an older interpreter can break.

Both are genuine breaks for consumers, so the major bump is correct rather than an artefact. It was chosen deliberately over stripping the labels to keep the release at v1.1.27 — that would have hidden exactly the breaks consumers need to see.

**Portfolio-wide.** Every repository extending this commons gets the resolver on its next release-drafter run. A repository that has been labelling PRs `breaking-change` without expecting a major bump will now get one. Worth a look at open drafts elsewhere before the next release round.

**Rollback:** revert this file; drafts recompute on the next run.
