### PR TITLE
docs: stop telling consumers to reference reusables at @develop

### DIFF
--- a/docs/de/getting-started/index.md
+++ b/docs/de/getting-started/index.md
@@ -44,7 +44,7 @@ on:
 
 jobs:
   static:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@develop
+    uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@<tag>
 ```
 
 !!! note "Referenz-Auswahl"

--- a/docs/de/index.md
+++ b/docs/de/index.md
@@ -63,7 +63,7 @@
     ```yaml
     jobs:
       static:
-        uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@develop
+        uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@<tag>
     ```
 
 === "Probot `_extends`"

--- a/docs/de/portfolio-app/setup.md
+++ b/docs/de/portfolio-app/setup.md
@@ -166,7 +166,7 @@ on:
 
 jobs:
   automerge:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-automerge.yaml@develop
+    uses: nolte/gh-plumbing/.github/workflows/reusable-automerge.yaml@<tag>
     with:
       app-id: ${{ vars.PORTFOLIO_APP_ID }}
     secrets:

--- a/docs/de/workflows/coverage.md
+++ b/docs/de/workflows/coverage.md
@@ -14,7 +14,7 @@ Beide rendern eine Markdown-Tabelle in `$GITHUB_STEP_SUMMARY` — auch wenn die 
 ```yaml title=".github/workflows/coverage.yaml"
 jobs:
   coverage:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-python-coverage.yaml@develop
+    uses: nolte/gh-plumbing/.github/workflows/reusable-python-coverage.yaml@<tag>
     with:
       coverage-source: my_package
       fail-under: 80
@@ -30,7 +30,7 @@ jobs:
 ```yaml title=".github/workflows/coverage.yaml"
 jobs:
   coverage:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-nodejs-coverage.yaml@develop
+    uses: nolte/gh-plumbing/.github/workflows/reusable-nodejs-coverage.yaml@<tag>
     with:
       fail-under: 80
 ```

--- a/docs/de/workflows/documentation.md
+++ b/docs/de/workflows/documentation.md
@@ -16,7 +16,7 @@ on:
 
 jobs:
   deliver_docs:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-mkdocs.yaml@develop
+    uses: nolte/gh-plumbing/.github/workflows/reusable-mkdocs.yaml@<tag>
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/docs/de/workflows/hacs.md
+++ b/docs/de/workflows/hacs.md
@@ -16,7 +16,7 @@ on:
 
 jobs:
   hacs-validate:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-hacs-validate.yaml@develop
+    uses: nolte/gh-plumbing/.github/workflows/reusable-hacs-validate.yaml@<tag>
 ```
 
 !!! tip "Custom-Repository vs. Default-Store"

--- a/docs/de/workflows/index.md
+++ b/docs/de/workflows/index.md
@@ -3,8 +3,24 @@
 Wiederverwendbare GitHub-Actions-Workflows liegen unter `.github/workflows/reusable-*.y{a}ml`. Konsumenten referenzieren sie über:
 
 ```yaml
-uses: nolte/gh-plumbing/.github/workflows/reusable-<name>.yaml@develop
+uses: nolte/gh-plumbing/.github/workflows/reusable-<name>.yaml@<tag>
 ```
+
+!!! warning "`<tag>` durch einen Release-Tag ersetzen, niemals `@develop`"
+
+    `<tag>` ist bewusst ein Platzhalter. Wähle eine Version auf der
+    [Releases-Seite](https://github.com/nolte/gh-plumbing/releases), zum
+    Beispiel `@v1.1.26`, und lass Renovate die Bumps vorschlagen.
+
+    Diese Seiten zeigten früher `@develop`. Konsumenten, die der Dokumentation
+    folgten, waren also *deshalb* ungepinnt. Eine Branch-Referenz löst auf das
+    auf, worauf der Branch zur Laufzeit zeigt — eine Änderung hier erreicht
+    deine CI sofort und ungeprüft.
+
+    Die Wrapper-Workflows dieses Repositories nutzen weiterhin `@develop`. Das
+    ist bewusstes Dogfooding des unveröffentlichten Stands, wird
+    [separat verfolgt](https://github.com/nolte/gh-plumbing/issues/392) und ist
+    kein Muster zum Nachbauen.
 
 ---
 

--- a/docs/de/workflows/release.md
+++ b/docs/de/workflows/release.md
@@ -21,7 +21,7 @@ on:
 
 jobs:
   update_release_draft:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-release-drafter.yml@develop
+    uses: nolte/gh-plumbing/.github/workflows/reusable-release-drafter.yml@<tag>
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -55,7 +55,7 @@ on:
 
 jobs:
   publish:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-release-publish.yml@develop
+    uses: nolte/gh-plumbing/.github/workflows/reusable-release-publish.yml@<tag>
     with:
       tag: ${{ inputs.tag }}
       dry_run: ${{ inputs.dry_run }}
@@ -85,7 +85,7 @@ on:
 
 jobs:
   refresh_presentation_branch:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-release-cd-refresh-master.yml@develop
+    uses: nolte/gh-plumbing/.github/workflows/reusable-release-cd-refresh-master.yml@<tag>
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/docs/de/workflows/static-tests.md
+++ b/docs/de/workflows/static-tests.md
@@ -15,7 +15,7 @@ on:
 
 jobs:
   static:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@develop
+    uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@<tag>
 ```
 
 !!! tip "Erforderlicher Status-Check"

--- a/docs/en/getting-started/index.md
+++ b/docs/en/getting-started/index.md
@@ -44,7 +44,7 @@ on:
 
 jobs:
   static:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@develop
+    uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@<tag>
 ```
 
 !!! note "Reference selection"

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -63,7 +63,7 @@
     ```yaml
     jobs:
       static:
-        uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@develop
+        uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@<tag>
     ```
 
 === "Probot `_extends`"

--- a/docs/en/portfolio-app/setup.md
+++ b/docs/en/portfolio-app/setup.md
@@ -162,7 +162,7 @@ on:
 
 jobs:
   automerge:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-automerge.yaml@develop
+    uses: nolte/gh-plumbing/.github/workflows/reusable-automerge.yaml@<tag>
     with:
       app-id: ${{ vars.PORTFOLIO_APP_ID }}
     secrets:

--- a/docs/en/workflows/coverage.md
+++ b/docs/en/workflows/coverage.md
@@ -14,7 +14,7 @@ Both render a Markdown table into `$GITHUB_STEP_SUMMARY` (even when the tests fa
 ```yaml title=".github/workflows/coverage.yaml"
 jobs:
   coverage:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-python-coverage.yaml@develop
+    uses: nolte/gh-plumbing/.github/workflows/reusable-python-coverage.yaml@<tag>
     with:
       coverage-source: my_package
       fail-under: 80
@@ -30,7 +30,7 @@ jobs:
 ```yaml title=".github/workflows/coverage.yaml"
 jobs:
   coverage:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-nodejs-coverage.yaml@develop
+    uses: nolte/gh-plumbing/.github/workflows/reusable-nodejs-coverage.yaml@<tag>
     with:
       fail-under: 80
 ```

--- a/docs/en/workflows/documentation.md
+++ b/docs/en/workflows/documentation.md
@@ -16,7 +16,7 @@ on:
 
 jobs:
   deliver_docs:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-mkdocs.yaml@develop
+    uses: nolte/gh-plumbing/.github/workflows/reusable-mkdocs.yaml@<tag>
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/docs/en/workflows/hacs.md
+++ b/docs/en/workflows/hacs.md
@@ -16,7 +16,7 @@ on:
 
 jobs:
   hacs-validate:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-hacs-validate.yaml@develop
+    uses: nolte/gh-plumbing/.github/workflows/reusable-hacs-validate.yaml@<tag>
 ```
 
 !!! tip "Custom repository vs. default store"

--- a/docs/en/workflows/index.md
+++ b/docs/en/workflows/index.md
@@ -3,8 +3,24 @@
 Reusable GitHub Actions workflows live under `.github/workflows/reusable-*.y{a}ml`. Consumers reference them via:
 
 ```yaml
-uses: nolte/gh-plumbing/.github/workflows/reusable-<name>.yaml@develop
+uses: nolte/gh-plumbing/.github/workflows/reusable-<name>.yaml@<tag>
 ```
+
+!!! warning "Replace `<tag>` with a release tag, never `@develop`"
+
+    `<tag>` is a placeholder on purpose. Pick a version from the
+    [releases page](https://github.com/nolte/gh-plumbing/releases), for example
+    `@v1.1.26`, and let Renovate propose the bumps.
+
+    These pages previously showed `@develop`, so consumers that followed them
+    ended up unpinned *because* they followed the documentation. A branch
+    reference resolves to whatever that branch points at when your workflow
+    runs, so a change here reaches your CI immediately and without review.
+
+    This repository's own wrapper workflows still use `@develop`. That is
+    deliberate dog-fooding of the unreleased state, is
+    [tracked separately](https://github.com/nolte/gh-plumbing/issues/392), and
+    is not a pattern to copy.
 
 ---
 

--- a/docs/en/workflows/release.md
+++ b/docs/en/workflows/release.md
@@ -21,7 +21,7 @@ on:
 
 jobs:
   update_release_draft:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-release-drafter.yml@develop
+    uses: nolte/gh-plumbing/.github/workflows/reusable-release-drafter.yml@<tag>
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -55,7 +55,7 @@ on:
 
 jobs:
   publish:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-release-publish.yml@develop
+    uses: nolte/gh-plumbing/.github/workflows/reusable-release-publish.yml@<tag>
     with:
       tag: ${{ inputs.tag }}
       dry_run: ${{ inputs.dry_run }}
@@ -84,7 +84,7 @@ on:
 
 jobs:
   refresh_presentation_branch:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-release-cd-refresh-master.yml@develop
+    uses: nolte/gh-plumbing/.github/workflows/reusable-release-cd-refresh-master.yml@<tag>
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/docs/en/workflows/static-tests.md
+++ b/docs/en/workflows/static-tests.md
@@ -15,7 +15,7 @@ on:
 
 jobs:
   static:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@develop
+    uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@<tag>
 ```
 
 !!! tip "Required status check"


### PR DESCRIPTION
## Summary

24 code samples across 18 documentation pages (EN and DE) instructed consumers to write:

```yaml
uses: nolte/gh-plumbing/.github/workflows/reusable-<name>.yaml@develop
```

Consumers that followed the documentation ended up unpinned **because** they followed it. This library was propagating the exact violation `spec/project/github-actions-best-practices/` §A forbids — at portfolio scale, and by instruction rather than by oversight.

This closes half **(a)** of #392. Half **(b)** — this repository's own nine `@develop` self-references — stays open, because it needs a spec decision rather than an edit.

## Changes

All 24 samples now read `@<tag>`. Both workflow index pages gain an admonition that names the releases page, explains what a branch reference actually resolves to, and states that this repository's own `@develop` wrappers are deliberate dog-fooding rather than a pattern to copy.

**Why a placeholder rather than a concrete tag.** `@v1.1.26` would be copy-pasteable, but it goes stale on the next release in 24 places with nothing keeping it honest — and a stale pin in documentation is a slower version of the same problem. A copy-pasteable `@develop` is precisely how this happened. The placeholder cannot go stale and forces the one decision the reader needs to make.

## Linked issues

Refs #392 — closes half (a). Half (b) is the self-reference carve-out, which needs a spec change in `claude-shared`, not an edit here.

## Testing

- `pre-commit run --all-files` — green.
- `vale sync` then `vale --minAlertLevel=suggestion` on both changed pages: **0 errors, 0 warnings, 0 suggestions**. One `Microsoft.Dashes` error on an added line was fixed before pushing; the remaining `HACS` acronym suggestions elsewhere in the file are pre-existing and untouched.
- `docs / MkDocs Build` exercises the pages that changed.

## Risk / rollout notes

**Issue:** #392 — Consumer docs instruct @develop, propagating an unpinned reusable-workflow reference portfolio-wide
**Classification:** `docs` with a `security` dimension — the documentation was the propagation mechanism for a supply-chain weakness.
**Specialist:** no matching specialised agent — generalist remediation. `audience-doc-author` needs an audience artefact this repository does not carry, and the change is a correction to existing samples rather than new prose.

**No behaviour change.** Documentation only; no workflow, config or consumer runtime is touched. Existing consumers keep working exactly as before — including the ones that are unpinned, who will not notice until they read the page again. If that matters, the follow-up is to tell them directly rather than to wait.

**Deliberately still open, and stated so in the docs themselves:** the nine wrapper workflows here keep `@develop`. There is a real argument for it — pinning them to a tag would make this repository dog-food its last *released* workflows rather than the ones on `develop`, so a regression would surface one release too late. The specs do not currently carry that exception, so the honest position is a documented, tracked deviation rather than a silent one. #392 stays open for the spec carve-out.

**Rollback:** documentation-only; revert the commit.
