### PR TITLE
docs: record four consumer-affecting decisions as ADRs

### DIFF
--- a/docs/de/decisions/adr-001-presentation-branch-reset.md
+++ b/docs/de/decisions/adr-001-presentation-branch-reset.md
@@ -1,0 +1,57 @@
+# ADR-001: Präsentationsbranch auf den Release-Tag zurücksetzen
+
+**Status:** Angenommen (2026-08-01) · **Issue:** [#384](https://github.com/nolte/gh-plumbing/issues/384)
+
+## Kontext
+
+Nach einem Release aktualisiert `reusable-release-cd-refresh-master.yml` den
+Präsentationsbranch (`main` oder `master`), damit er dem neuesten Release folgt.
+Bisher geschah das mit `devmasx/merge-branch`, das die GitHub-`merges`-API
+aufruft. Diese API erzeugt einen Merge-Commit.
+
+Ein Consumer, dessen Präsentationsbranch ein Linear-History-Ruleset trägt, weist
+den Aufruf ab:
+
+```text
+POST /repos/nolte/workstation/merges: 409
+This branch must not contain merge commits.
+```
+
+Das Release selbst wird veröffentlicht und die Doku ausgeliefert. Nur der
+Präsentationsbranch bleibt stehen, weshalb der Fehler leicht übersehen wird.
+
+Der Branch driftet zudem. In diesem Repository trägt `master` synthetische
+Merge-Commits, die es auf `develop` nie gab, und `master` ist kein Ancestor von
+`develop`. Ein einfacher Fast-Forward-Push wird deshalb ebenfalls abgewiesen.
+
+## Entscheidung
+
+Den Merge durch einen `force-with-lease`-Push des Release-Tags auf den
+Zielbranch ersetzen. Der Lease-Wert stammt aus dem Lesen der Ziel-Ref unmittelbar
+vor dem Push, sodass eine nebenläufige Aktualisierung abbricht statt Daten zu
+verlieren.
+
+## Erwogene Alternativen
+
+**Die Release-App vom Ruleset ausnehmen.** Verworfen. Es höhlt eine Regel aus,
+die der Consumer bewusst gesetzt hat, und muss in jedem Repository wiederholt
+werden.
+
+**Dokumentieren, dass Consumer kein Linear-History-Ruleset setzen dürfen.**
+Verworfen. Es verlagert eine Einschränkung auf den Consumer, statt das geteilte
+Werkzeug zu reparieren.
+
+## Folgen
+
+Der Präsentationsbranch wird zum exakten Spiegel des Release-Tags, was er immer
+zu sein behauptet hat. Das Zurücksetzen verwirft die synthetischen Merge-Commits
+des alten Mechanismus. Nichts referenziert sie.
+
+Der Workflow hängt nicht länger von `devmasx/merge-branch` ab, was eine
+Third-Party-Action aus einem Schritt entfernt, der `contents: write` gegen einen
+geschützten Branch hält.
+
+Consumer sehen beim nächsten Release einen History-Rewrite auf dem
+Präsentationsbranch. Dieser Branch ist als automatisch aktualisiert dokumentiert
+und nicht als Ort zum Committen, es sollte also keine Arbeit verloren gehen. Wer
+dort lokale Commits hält, muss sie vorher verschieben.

--- a/docs/de/decisions/adr-002-branch-protection-verification.md
+++ b/docs/de/decisions/adr-002-branch-protection-verification.md
@@ -1,0 +1,58 @@
+# ADR-002: Branch Protection prüfen, bevor die Defaults geändert werden
+
+**Status:** Angenommen (2026-08-01) · **Issue:** [#387](https://github.com/nolte/gh-plumbing/issues/387)
+
+## Kontext
+
+In `.github/settings.yml` deklarierte Branch Protection wird häufig nicht
+angewendet. Die Deklaration sieht korrekt aus, die Probot-Settings-App meldet
+nichts, und der Schutz fehlt. Eine Erhebung über neun Consumer am 2026-07-26 fand
+fünf mit Drift, in mindestens drei verschiedenen Ausprägungen.
+
+Eine Ursache ist bestätigt. Die Commons deklarieren `restrictions.apps` für
+`develop` und `master`. GitHub akzeptiert Push-Restriktionen nur bei
+organisationseigenen Repositories, und `nolte` ist ein Nutzerkonto. Die
+Settings-App verwirft daraufhin die gesamte Protection-Aktualisierung, statt nur
+das eine nicht unterstützte Feld zu überspringen.
+
+Diese Ursache erklärt den Rest nicht. Drei Repositories deklarieren
+`restrictions: null` und haben trotzdem gar keinen Schutz. Eines hat Schutz mit
+null Kontexten, obwohl es einen deklariert. Ein weiteres erhält drei seiner vier
+deklarierten Kontexte.
+
+## Entscheidung
+
+Einen Check bauen, der deklarierte gegen tatsächliche Protection über das
+Portfolio vergleicht, und ihn nach Zeitplan laufen lassen. Erst danach anhand
+seiner Ergebnisse entscheiden, was sich in den Commons ändert.
+
+## Erwogene Alternativen
+
+**`restrictions` jetzt aus den `develop`-Commons entfernen.** Vorerst verworfen.
+Es würde den Fall dieses Repositories schließen und vier ungeklärte unberührt
+lassen, während es aussähe, als wäre das Problem gelöst.
+
+**Jeden Consumer `restrictions: null` deklarieren lassen.** Verworfen. Es
+wiederholt Boilerplate in jedem Repository, und ein Vergessen scheitert lautlos,
+was genau der Mechanismus hinter diesem Problem ist.
+
+**Das Portfolio in eine Organisation überführen.** Zurückgestellt. Damit
+funktionierte `restrictions.apps` wie vorgesehen, aber die Folgen reichen weit
+über Branch Protection hinaus.
+
+## Folgen
+
+Die prägende Eigenschaft dieser Fehlerklasse ist Unsichtbarkeit. Es gibt keinen
+Fehler, kein Log und keinen roten Check. Das Repository sieht konfiguriert aus
+und ist es nicht. Niemand merkt es, bis ein Merge durchgeht, der hätte blockiert
+werden müssen. Ein Vergleichs-Check adressiert diese Eigenschaft statt eines
+einzelnen Vorkommens.
+
+Solange der Check fehlt, ist jede Behauptung, ein Required Check sei in diesem
+Portfolio aktiv, unbelegt. [ADR-003](adr-003-workflow-validation-gate.md) fügt
+einen Required Check hinzu und erbt diesen Zweifel. Seine Akzeptanzkriterien
+verlangen deshalb eine Prüfung über die API statt über die Einstellungsseite.
+
+Die offene Frage, ob `restrictions` auf `develop` überhaupt etwas bringt, bleibt
+offen. Die Commons begründen es für `master`, wo die Release-Kaskade mit einem
+App-Token pusht. Diese Begründung überträgt sich nicht ohne Weiteres.

--- a/docs/de/decisions/adr-003-workflow-validation-gate.md
+++ b/docs/de/decisions/adr-003-workflow-validation-gate.md
@@ -1,0 +1,56 @@
+# ADR-003: Workflow-Gültigkeit über einen Required Check absichern
+
+**Status:** Angenommen (2026-08-01) · **Issue:** [#398](https://github.com/nolte/gh-plumbing/issues/398)
+
+## Kontext
+
+`reusable-hacs-validate.yaml` scheiterte fünf Wochen lang an GitHubs
+Workflow-Validierung. Die Datei nutzte eine Expression im `uses:` eines Steps,
+was GitHub Actions nicht unterstützt. Sie ließ sich also nie parsen, der Workflow
+lief nie, und kein Consumer konnte ihn aufrufen.
+
+GitHub meldet das durchaus. Es erzeugt einen Run, benannt nach dem Dateipfad, mit
+null Jobs. Dieser Run stand ab dem 2026-06-26 rot auf `develop`. Übersehen wurde
+er, weil er nichts blockiert, weil er nach einem Pfad statt nach einem Workflow
+heißt, und weil er nur wieder auftaucht, wenn die Datei selbst sich ändert.
+
+Das Signal existierte. Niemand handelte darauf.
+
+## Entscheidung
+
+`reusable-actionlint.yaml` hinzufügen, in `build-static-tests.yaml` einhängen und
+den Job-Namen in die Required Status Checks für `develop` aufnehmen.
+
+Separat die defekte Datei reparieren: den Action-Digest direkt eintragen und den
+Input entfernen, der die nicht unterstützte Expression speiste. Dieser Input
+existierte ausschließlich dafür, es gibt also keine Variante, die beides behält.
+
+## Erwogene Alternativen
+
+**Den Check hinzufügen, ohne ihn verpflichtend zu machen.** Verworfen, anhand der
+Evidenz dieses Issues. Ein nicht blockierendes Signal existierte bereits und
+wurde fünf Wochen ignoriert. Ein zweites würde denselben Fehler mit besserem
+Werkzeug wiederholen.
+
+**Stattdessen die vorhandenen Validierungs-Runs beobachten.** Verworfen. Das
+verlässt sich darauf, dass jemand hinschaut, und genau das hat hier versagt.
+`actionlint` findet zudem mehr: ungültige Expression-Kontexte, falsche
+`uses:`-Formen, Shell-Probleme in `run:`-Blöcken und Typfehler in Inputs.
+
+**Den defekten Input als deprecated No-Op behalten.** Verworfen. Ein
+Deprecation-Shim schützt funktionierende Aufrufer, und es gab keine.
+
+## Folgen
+
+Der Check kommt als wiederverwendbarer Workflow statt als Inline-Schritte, damit
+Consumer ihn erben. Eine Bibliothek geteilter Workflows, die nur die eigenen
+Workflows lintet, würde denselben Fehler eine Ebene höher wiederholen.
+
+Der erste Lauf wird mehr als eine defekte Datei finden. Dreißig Workflow-Dateien
+wurden nie gelintet. Deshalb landet zuerst das Reusable, dann wird der Baum
+sauber, und erst zuletzt kommt der Required Context dazu. Umgekehrt würde jeder
+Pull Request an unbeteiligten Altbefunden hängen.
+
+Consumer erhalten einen Check, der einen Pull Request rot macht, dessen
+Workflow-Dateien sich nicht parsen lassen. Repositories mit bereits ungültigen
+Workflow-Dateien bekommen diese zu sehen.

--- a/docs/de/decisions/adr-004-spec-drift-routing.md
+++ b/docs/de/decisions/adr-004-spec-drift-routing.md
@@ -1,0 +1,49 @@
+# ADR-004: Den Q2-Spec-Drift-Cluster über die Roadmap führen
+
+**Status:** Angenommen (2026-08-01) · **Issue:** [#386](https://github.com/nolte/gh-plumbing/issues/386)
+
+## Kontext
+
+Das Spec-Drift-Audit 2026-Q2 von `nolte/claude-shared` hinterließ ein Bündel von
+Befunden, die in dieses Repository gehören und nicht in einen Consumer. Eine
+Referenz auf einen wiederverwendbaren Workflow zu bauen, den es nicht gibt, würde
+die CI eines Consumers brechen. Die Arbeit muss also zuerst hier geschehen.
+
+Das Bündel spannt vier getrennte Outcomes:
+
+1. ein PR-Lint-Reusable, dazu die Übernahme durch Consumer und ein neuer Required Check
+2. fünf Härtungen an `reusable-release-publish.yml`, mehrere davon Gates
+3. zwei Pre-Release-Gates, für Doku-Frische und Release-Notes-Prosa
+4. ein `exp/`-`autolabeler`-Eintrag in den Release-Drafter-Commons
+
+## Entscheidung
+
+Ein Roadmap-Item für die Outcomes eins bis drei anlegen und in Features zerlegen.
+Den `exp/`-`autolabeler`-Eintrag separat und vorab ausliefern.
+
+## Erwogene Alternativen
+
+**In vier Issues aufteilen und einzeln abarbeiten.** Verworfen. Die
+Issue-Orchestration-Spec führt Arbeit, die mehr als ein Outcome umfasst, in die
+Planungsebene. Vier einzeln abgearbeitete Issues würden sie umgehen.
+
+**Zuerst die Release-Härtungen umsetzen und den Rest später planen.** Verworfen.
+Das mischt Routen, und die Spec verbietet eine Teilumsetzung, die den Rest
+ungeplant lässt.
+
+## Folgen
+
+Alle drei Roadmap-Items dieses Repositories tragen `status: done`. Es braucht
+also ein neues statt einer Änderung an einem bestehenden.
+
+Der `exp/`-`autolabeler`-Eintrag ist eine einzelne Ergänzung an einer
+Commons-Datei. Er hängt an nichts anderem im Bündel, und nichts hängt an ihm. In
+einem Sammel-Item würde er auf einen Sprint warten, den er nicht braucht. Ihn
+vorzuziehen ist eine hier festgehaltene Scope-Entscheidung, kein ungeplanter
+Rest.
+
+Zwei Abhängigkeiten zählen bei der Planung. Die Release-Härtung betrifft ein
+anstehendes Major-Release, und zwei ihrer Punkte sichern gegen Fehler ab, die
+bereits einmal aufgetreten sind. Der PR-Lint-Check fügt einen Required Status
+Context hinzu, von dem sich laut [ADR-002](adr-002-branch-protection-verification.md)
+noch nicht belegen lässt, dass er greift.

--- a/docs/de/decisions/index.md
+++ b/docs/de/decisions/index.md
@@ -1,0 +1,26 @@
+# Entscheidungen
+
+Architecture Decision Records für Entscheidungen, die über dieses Repository
+hinaus wirken.
+
+`gh-plumbing` ist eine reine Konfigurationsbibliothek. Ihre wiederverwendbaren
+Workflows und Probot-Commons laufen in jedem Consumer-Repository, eine
+Entscheidung hier verändert also fremde CI ohne deren Zutun. Diese Aufzeichnungen
+gibt es, damit ein Consumer das Warum findet, ohne einen geschlossenen
+Issue-Thread zu lesen.
+
+Entscheidungen, die nur dieses Repository betreffen, bleiben in ihrem Issue. Hier
+landet, was verändert, was Consumer erben.
+
+| Record | Thema | Status |
+|---|---|---|
+| [ADR-001](adr-001-presentation-branch-reset.md) | Präsentationsbranch auf den Release-Tag zurücksetzen | Angenommen |
+| [ADR-002](adr-002-branch-protection-verification.md) | Branch Protection prüfen, bevor die Defaults geändert werden | Angenommen |
+| [ADR-003](adr-003-workflow-validation-gate.md) | Workflow-Gültigkeit über einen Required Check absichern | Angenommen |
+| [ADR-004](adr-004-spec-drift-routing.md) | Den Q2-Spec-Drift-Cluster über die Roadmap führen | Angenommen |
+
+## Format
+
+Jede Aufzeichnung nennt den Kontext, die Entscheidung, die unterlegenen
+Alternativen und die Folgen, mit denen ein Consumer rechnen sollte. Das jeweils
+verlinkte GitHub-Issue trägt die Akzeptanzkriterien und die Umsetzungsspur.

--- a/docs/en/decisions/adr-001-presentation-branch-reset.md
+++ b/docs/en/decisions/adr-001-presentation-branch-reset.md
@@ -1,0 +1,54 @@
+# ADR-001: Reset the presentation branch to the release tag
+
+**Status:** Accepted (2026-08-01) · **Issue:** [#384](https://github.com/nolte/gh-plumbing/issues/384)
+
+## Context
+
+After a release, `reusable-release-cd-refresh-master.yml` updates the
+presentation branch (`main` or `master`) so it tracks the newest release. It did
+this with `devmasx/merge-branch`, which calls the GitHub `merges` API. That API
+creates a merge commit.
+
+A consumer whose presentation branch carries a linear-history ruleset rejects
+that call:
+
+```text
+POST /repos/nolte/workstation/merges: 409
+This branch must not contain merge commits.
+```
+
+The release itself publishes and the docs deploy. Only the presentation branch
+stays stale, so the failure is easy to miss.
+
+The branch also drifts. In this repository `master` carries synthetic merge
+commits that never existed on `develop`, and `master` isn't an ancestor of
+`develop`. A plain fast-forward push is therefore rejected as well.
+
+## Decision
+
+Replace the merge with a force-with-lease push of the release tag onto the
+target branch. The lease value comes from reading the target ref immediately
+before the push, so a concurrent update aborts instead of losing data.
+
+## Alternatives considered
+
+**Exempt the release App from the ruleset.** Rejected. It hollows out a rule the
+consumer set deliberately, and it has to be repeated in every repository.
+
+**Document that consumers must not apply a linear-history ruleset.** Rejected.
+It moves a constraint onto the consumer instead of repairing the shared tool.
+
+## Consequences
+
+The presentation branch becomes an exact mirror of the release tag, which is
+what it always claimed to be. The reset discards the synthetic merge commits the
+old mechanism produced. Nothing references them.
+
+The workflow no longer depends on `devmasx/merge-branch`, which removes one
+third-party action from a step holding `contents: write` against a protected
+branch.
+
+Consumers see a history rewrite on the presentation branch at the next release.
+That branch is documented as automatically refreshed and not a place to commit
+to, so no work should be lost. Anyone holding local commits there needs to move
+them first.

--- a/docs/en/decisions/adr-002-branch-protection-verification.md
+++ b/docs/en/decisions/adr-002-branch-protection-verification.md
@@ -1,0 +1,56 @@
+# ADR-002: Verify branch protection before changing its defaults
+
+**Status:** Accepted (2026-08-01) · **Issue:** [#387](https://github.com/nolte/gh-plumbing/issues/387)
+
+## Context
+
+Branch protection declared in `.github/settings.yml` is often not applied. The
+declaration looks correct, the Probot Settings App reports nothing, and the
+protection is absent. A survey of nine consumers on 2026-07-26 found five that
+drift, in at least three different shapes.
+
+One cause is confirmed. The commons declare `restrictions.apps` for `develop`
+and `master`. GitHub accepts push restrictions only on organisation-owned
+repositories, and `nolte` is a user account. The Settings App drops the whole
+protection update rather than skipping the one unsupported field.
+
+That cause doesn't explain the rest. Three repositories declare
+`restrictions: null` and still have no protection at all. One has protection
+with zero contexts despite declaring one. Another receives three of its four
+declared contexts.
+
+## Decision
+
+Build a check that compares declared protection against live protection across
+the portfolio, and run it on a schedule. Decide what to change in the commons
+afterwards, using its output.
+
+## Alternatives considered
+
+**Remove `restrictions` from the `develop` commons now.** Rejected for the
+moment. It would close this repository's case and leave four unexplained ones
+untouched, while looking like the problem was solved.
+
+**Have every consumer declare `restrictions: null`.** Rejected. It repeats
+boilerplate in every repository, and forgetting it fails silently, which is the
+mechanism that caused this.
+
+**Move the portfolio to an organisation.** Deferred. It would make
+`restrictions.apps` work as designed, but its consequences reach well beyond
+branch protection.
+
+## Consequences
+
+The defining property of this class of fault is invisibility. There is no error,
+no log, and no failed check. The repository looks configured and isn't. Nobody
+notices until a merge that should have been blocked goes through. A comparison
+check addresses that property rather than one instance of it.
+
+Until the check exists, any claim that a required status check is active in this
+portfolio is unproven. [ADR-003](adr-003-workflow-validation-gate.md) adds a
+required check and therefore inherits this doubt. Its acceptance criteria call
+for verification through the API rather than the settings page.
+
+The open question of whether `restrictions` on `develop` serves any purpose
+stays open. The commons justify it for `master`, where the release cascade
+pushes with an App token. That reasoning doesn't obviously transfer.

--- a/docs/en/decisions/adr-003-workflow-validation-gate.md
+++ b/docs/en/decisions/adr-003-workflow-validation-gate.md
@@ -1,0 +1,54 @@
+# ADR-003: Gate workflow validity on a required check
+
+**Status:** Accepted (2026-08-01) · **Issue:** [#398](https://github.com/nolte/gh-plumbing/issues/398)
+
+## Context
+
+`reusable-hacs-validate.yaml` failed GitHub's workflow validation for five
+weeks. It used an expression in a step's `uses:` keyword, which GitHub Actions
+doesn't support, so the file never parsed and the workflow never ran. No
+consumer could call it.
+
+GitHub does report this. It creates a run named after the file path, carrying
+zero jobs. That run sat red on `develop` from 2026-06-26 onward. It went
+unnoticed because it blocks nothing, it's named after a path rather than a
+workflow, and it only reappears when the file itself changes.
+
+The signal existed. Nothing acted on it.
+
+## Decision
+
+Add `reusable-actionlint.yaml`, wire it into `build-static-tests.yaml`, and add
+its job name to the required status checks for `develop`.
+
+Separately, repair the broken file by pinning the action digest directly and removing
+the input that fed the unsupported expression. That input existed only to feed
+it, so no version of the file keeps both.
+
+## Alternatives considered
+
+**Add the check without making it required.** Rejected on this issue's own
+evidence. A non-blocking signal already existed and was ignored for five weeks.
+A second one would reproduce the failure with better tooling.
+
+**Watch the existing validation runs instead.** Rejected. It relies on someone
+looking, which is what failed here. `actionlint` also catches more: invalid
+expression contexts, unknown `uses:` shapes, shell issues in `run:` blocks, and
+type errors in inputs.
+
+**Keep the broken input as a deprecated no-op.** Rejected. A deprecation shim
+protects working callers, and there were none.
+
+## Consequences
+
+The check ships as a reusable workflow rather than as inline steps, so consumers
+inherit it. A shared workflow library that lints only its own workflows would
+repeat this fault one level up.
+
+The first run will find more than one broken file. Thirty workflow files have
+never been linted. The reusable therefore lands first, the tree gets clean, and
+the required context comes last. Adding the context first would block every pull
+request on unrelated findings.
+
+Consumers gain a check that fails a pull request whose workflow files don't
+parse. Repositories that already carry invalid workflow files will see them.

--- a/docs/en/decisions/adr-004-spec-drift-routing.md
+++ b/docs/en/decisions/adr-004-spec-drift-routing.md
@@ -1,0 +1,48 @@
+# ADR-004: Route the Q2 spec-drift cluster through the roadmap
+
+**Status:** Accepted (2026-08-01) · **Issue:** [#386](https://github.com/nolte/gh-plumbing/issues/386)
+
+## Context
+
+The 2026-Q2 spec-drift audit of `nolte/claude-shared` left a cluster of findings
+that belong in this repository rather than in a consumer. Building a reference
+to a reusable workflow that doesn't exist would break a consumer's CI, so the
+work has to happen upstream first.
+
+The cluster spans four separate outcomes:
+
+1. a PR-lint reusable workflow, plus adoption by consumers and a new required check
+2. five hardening items on `reusable-release-publish.yml`, several of them gates
+3. two pre-release gates, for documentation freshness and release-notes prose
+4. an `exp/` `autolabeler` in the release-drafter commons
+
+## Decision
+
+Create a roadmap item for outcomes one to three and decompose it into features.
+Ship the `exp/` `autolabeler` entry separately, ahead of that work.
+
+## Alternatives considered
+
+**Split into four issues and work them individually.** Rejected. The issue-
+orchestration spec routes work spanning more than one outcome into the planning
+layer. Four issues worked one at a time would bypass it.
+
+**Implement the release hardening first and plan the rest later.** Rejected. It
+mixes routes, and the spec forbids a partial implementation that leaves the
+remainder unplanned.
+
+## Consequences
+
+All three roadmap items in this repository carry `status: done`, so this needs a
+new one rather than a change to an existing one.
+
+The `exp/` `autolabeler` entry is one addition to a single commons file. It depends on
+nothing else in the cluster and nothing depends on it. Inside a collective item
+it would wait for a sprint it doesn't need. Pulling it forward is a scope
+decision recorded here, not an unplanned remainder.
+
+Two dependencies matter when the work gets planned. The release hardening bears
+on a pending major release, and two of its items guard against faults that have
+already occurred once. The PR-lint check adds a required status context, which
+[ADR-002](adr-002-branch-protection-verification.md) shows can't yet be proven
+to take effect.

--- a/docs/en/decisions/index.md
+++ b/docs/en/decisions/index.md
@@ -1,0 +1,24 @@
+# Decisions
+
+Architecture decision records for choices that reach beyond this repository.
+
+`gh-plumbing` is a configuration-only library. Its reusable workflows and Probot
+commons run inside every consumer repository, so a decision here changes other
+people's CI without their involvement. These records exist so a consumer can
+find out why, without reading a closed issue thread.
+
+Decisions that only affect this repository stay in their issue. A record lands
+here when it changes what consumers inherit.
+
+| Record | Subject | Status |
+|---|---|---|
+| [ADR-001](adr-001-presentation-branch-reset.md) | Reset the presentation branch to the release tag | Accepted |
+| [ADR-002](adr-002-branch-protection-verification.md) | Verify branch protection before changing its defaults | Accepted |
+| [ADR-003](adr-003-workflow-validation-gate.md) | Gate workflow validity on a required check | Accepted |
+| [ADR-004](adr-004-spec-drift-routing.md) | Route the Q2 spec-drift cluster through the roadmap | Accepted |
+
+## Format
+
+Each record states the context, the decision, the alternatives that lost, and
+the consequences a consumer should expect. The GitHub issue linked from each
+record carries the acceptance criteria and the implementation trail.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ plugins:
             Portfolio App: Portfolio-App
             Setup: Setup
             Development: Entwicklung
+            Decisions: Entscheidungen
 
 markdown_extensions:
   - abbr
@@ -145,5 +146,11 @@ nav:
       - Labelling: probot/labelling.md
   - Portfolio App:
       - Setup: portfolio-app/setup.md
+  - Decisions:
+      - decisions/index.md
+      - ADR-001 Presentation branch: decisions/adr-001-presentation-branch-reset.md
+      - ADR-002 Branch protection: decisions/adr-002-branch-protection-verification.md
+      - ADR-003 Workflow validation: decisions/adr-003-workflow-validation-gate.md
+      - ADR-004 Spec-drift routing: decisions/adr-004-spec-drift-routing.md
   - Development:
       - development/index.md


### PR DESCRIPTION
## Summary

Adds a `Decisions` section to the documentation with four architecture decision records, in English and German.

Six decisions were taken on 2026-08-01 while working through the open issue backlog. All six are recorded as issue comments carrying their acceptance criteria. **Four of them change what consumers inherit**, and a consumer cannot reasonably be expected to find a closed issue thread — so those four also become records here.

The two that stay issue-only are internal: how this repository's own wrapper workflows reference their reusables (#392), and the ordering of the next release (#394).

## Changes

| Record | Decision | Issue |
|---|---|---|
| ADR-001 | Reset the presentation branch to the release tag instead of merging into it | #384 |
| ADR-002 | Build declared-versus-live verification before changing branch-protection defaults | #387 |
| ADR-003 | Gate workflow validity on a required `actionlint` check | #398 |
| ADR-004 | Route the Q2 spec-drift cluster through the roadmap, pull the `exp/` entry forward | #386 |

Each record states the context, the decision, **the alternatives that lost and why**, and the consequences a consumer should expect. The alternatives section is the point: three of these four had a cheaper option that was rejected for a reason worth remembering.

Nav entries in both locales, with `Decisions: Entscheidungen` added to `nav_translations`.

## Linked issues

Refs #384, #386, #387, #398 — recording only; none of the four is implemented by this PR.

## Testing

- `mkdocs build --strict` — green, both locales, 14 navigation elements translated.
- `vale --minAlertLevel=error` on all ten new pages — **0 errors, 0 warnings, 0 suggestions**. 19 errors were fixed before pushing rather than left to the CI annotation cap. `docs/de/**` carries `BasedOnStyles =` in `.vale.ini`, so German pages are exempt by configuration.
- `pre-commit run --all-files` — green.

**One vocabulary addition:** `[Rr]uleset` in the local `accept.txt`. It is GitHub's own product term and appears three times in ADR-001. The other flagged words were handled without touching the vocabulary — `autolabeler` is a release-drafter config key and now carries code formatting, and `rollout`, `retarget` and `hardcoding` were rephrased. Worth revisiting whether `ruleset` belongs upstream in `nolte/vale-style` rather than locally.

## Risk / rollout notes

**Issues:** #384, #386, #387, #398
**Classification:** `docs` — recording decisions already taken.
**Specialist:** no matching specialised agent — generalist remediation. `audience-doc-author` requires an audience artefact this repository does not carry.

**No behaviour change.** Documentation only. No workflow, config or consumer runtime is touched, and none of the four decisions is implemented here — these records describe intent, and each links the issue where the acceptance criteria live.

**Deliberately partial.** Publishing a record before its implementation is the intended order: ADR-001 and ADR-003 both describe changes consumers will notice, and a consumer who reads the release notes should be able to find out why before the change arrives. The records say what will happen, not what has happened.

**Rollback:** documentation-only; revert the commit and drop the nav entries.
