### PR TITLE
fix(release): reset the presentation branch instead of merging into it

### DIFF
--- a/.github/workflows/release-cd-refresh-master.yml
+++ b/.github/workflows/release-cd-refresh-master.yml
@@ -20,7 +20,7 @@ permissions:
 
 
 # This wrapper pushes a fast-forward merge to master through
-# `devmasx/merge-branch`. After Phase 2 of issue #330 lands its
+# the force-with-lease push. After Phase 2 of issue #330 lands its
 # push-restriction (`restrictions.apps: [nolte-portfolio-app]`) on
 # master, `GITHUB_TOKEN` no longer has the right to push to master —
 # the App token is now mandatory. Forwarding `vars.PORTFOLIO_APP_ID`
@@ -39,7 +39,10 @@ jobs:
       contents: write # the called workflow pushes to the presentation branch
     uses: nolte/gh-plumbing/.github/workflows/reusable-release-cd-refresh-master.yml@develop
     with:
-      from_branch: ${{ inputs.tag || github.event.ref }}
+      # github.event.release.tag_name, not github.event.ref: the release
+      # payload carries no top-level `ref`, so the old expression resolved
+      # to the empty string on every release-triggered run.
+      from_branch: ${{ inputs.tag || github.event.release.tag_name }}
       app-id: ${{ vars.PORTFOLIO_APP_ID }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-release-cd-refresh-master.yml
+++ b/.github/workflows/reusable-release-cd-refresh-master.yml
@@ -4,8 +4,17 @@ on:
   workflow_call:
     inputs:
       from_branch:
+        description: |
+          Git ref the presentation branch is reset to -- normally the published
+          release tag. Defaults to `github.event.release.tag_name`, which the
+          `release` payload actually carries. It previously defaulted to
+          `github.event.ref`, a field that payload does NOT carry: the value
+          resolved to the empty string on every release, and the old merge step
+          silently fell back to the default branch. The presentation branch
+          therefore tracked `develop`'s tip rather than the release tag, and
+          only looked right because tags are cut at that tip.
         required: false
-        default: ${{ github.event.ref }}
+        default: ${{ github.event.release.tag_name }}
         type: string
       target_branch:
         required: false
@@ -61,8 +70,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Mint an App installation token only when the caller has set
-      # inputs.app-id. The output token replaces secrets.token in the
-      # devmasx/merge-branch step via the
+      # inputs.app-id. The output token replaces secrets.token for the
+      # checkout and the push via the
       # `steps.app-token.outputs.token || secrets.token` fallback.
       - name: Mint App installation token
         id: app-token
@@ -79,12 +88,70 @@ jobs:
           app-id: ${{ inputs.app-id }}
           private-key: ${{ secrets.app-private-key }}
 
-      - name: Checkout master
+      - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-      - name: Merge Tag -> Master
-        uses: devmasx/merge-branch@854d3ac71ed1e9deb668e0074781b81fdd6e771f # 1.4.0
         with:
-          type: now
-          from_branch: ${{ inputs.from_branch }}
-          target_branch: ${{ inputs.target_branch }}
-          github_token: ${{ steps.app-token.outputs.token || secrets.token }}
+          # Full history plus tags: the reset resolves an arbitrary ref to a
+          # commit, which a shallow clone cannot do.
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token || secrets.token }}
+
+      # Reset rather than merge. The presentation branch is a throwaway mirror
+      # of the release tag, so pointing it at the tag says what the branch is
+      # for. The previous `devmasx/merge-branch` step called the `merges` API,
+      # which creates a merge commit and is rejected outright by a
+      # linear-history ruleset on the target (see issue #384).
+      - name: Reset the presentation branch to the release ref
+        env:
+          FROM_REF: ${{ inputs.from_branch }}
+          TARGET: ${{ inputs.target_branch }}
+        run: |
+          set -euo pipefail
+
+          # Fail loudly rather than defaulting. An empty ref is what made the
+          # old behaviour wrong-but-green for every release so far.
+          if [ -z "${FROM_REF}" ]; then
+            echo "::error::from_branch resolved to an empty value. On a release" \
+                 "trigger it defaults to github.event.release.tag_name; on a" \
+                 "manual run, pass the tag explicitly." >&2
+            exit 1
+          fi
+
+          git fetch --force --tags --prune origin
+
+          # Accept a tag, a branch or a raw SHA, in that order of preference.
+          SOURCE_SHA="$(
+            git rev-parse --verify --quiet "refs/tags/${FROM_REF}^{commit}" ||
+            git rev-parse --verify --quiet "refs/remotes/origin/${FROM_REF}^{commit}" ||
+            git rev-parse --verify --quiet "${FROM_REF}^{commit}"
+          )" || {
+            echo "::error::Could not resolve '${FROM_REF}' to a commit." >&2
+            exit 1
+          }
+
+          EXPECTED="$(git ls-remote origin "refs/heads/${TARGET}" | awk '{print $1}')"
+
+          if [ -z "${EXPECTED}" ]; then
+            echo "Target branch '${TARGET}' does not exist yet; creating it."
+            git push origin "${SOURCE_SHA}:refs/heads/${TARGET}"
+          elif [ "${EXPECTED}" = "${SOURCE_SHA}" ]; then
+            echo "Target branch '${TARGET}' already points at ${SOURCE_SHA}; nothing to do."
+          else
+            # --force-with-lease, not --force: if another run advanced the
+            # target between the read above and this push, the push aborts
+            # instead of discarding that run's work. The concurrency group on
+            # this workflow makes that unlikely; the lease makes it safe.
+            git push --force-with-lease="${TARGET}:${EXPECTED}" \
+              origin "${SOURCE_SHA}:refs/heads/${TARGET}"
+          fi
+
+          {
+            echo "### Presentation branch refreshed"
+            echo
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Source ref | \`${FROM_REF}\` |"
+            echo "| Source commit | \`${SOURCE_SHA}\` |"
+            echo "| Target branch | \`${TARGET}\` |"
+            echo "| Previous target commit | \`${EXPECTED:-<branch did not exist>}\` |"
+          } >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
## Summary

`reusable-release-cd-refresh-master.yml` updated the presentation branch with `devmasx/merge-branch`, which calls the GitHub `merges` API and therefore **creates a merge commit**. A consumer whose presentation branch carries a linear-history ruleset rejects that call outright:

```text
POST /repos/nolte/workstation/merges: 409
This branch must not contain merge commits.
```

The release publishes and the docs deploy, so only the presentation branch stays stale — easy to miss, and it recurs on every release.

Replaced with a force-with-lease push of the release ref onto the target. Decision recorded in [ADR-001](https://nolte.github.io/gh-plumbing/decisions/adr-001-presentation-branch-reset/).

Closes #384

## A second defect, found while implementing this

**The workflow has never actually delivered the release tag.**

`from_branch` defaulted to `${{ github.event.ref }}`. The `release` payload carries no top-level `ref`, so on every release-triggered run the value resolved to the **empty string** — confirmed in the last run's log:

```text
from_branch:
target_branch: master
```

`devmasx/merge-branch` then fell back to the default branch. The presentation branch has been tracking **`develop`'s tip**, not the release tag. It looked correct only because tags are cut at that tip: `v1.1.26` points at `bab4f9d`, and `bab4f9d` is what `master` received.

The failure mode this hides: anything landing on `develop` between the tag being created and the cascade running would be delivered to `master` **without being in the release**. The presentation branch would advertise content the release does not contain.

Both the reusable's default and the caller now use `github.event.release.tag_name`, which that payload does carry. An empty ref now fails loudly instead of defaulting.

## Changes

- The merge step becomes a resolve-then-push step: the ref is resolved to a commit (tag, then branch, then raw SHA), the target's current value is read, and the push carries `--force-with-lease` against that value.
- An empty or unresolvable ref exits non-zero with an explicit message.
- The step writes a job summary naming the source ref, source commit, target branch and previous target commit.
- `devmasx/merge-branch` is gone — one fewer third-party action in a step holding `contents: write` against a protected branch.

## Linked issues

Closes #384

## Testing

`pre-commit run --all-files` — green. YAML parsed and step list asserted.

**The shell logic was tested against a real git repository**, extracting the exact `run:` block from the workflow so the test exercises shipped code rather than a copy. Six cases, all passing:

| Case | Result |
|---|---|
| Diverged target reset to the tag — this repository's actual `master` shape | target ends at the tag commit |
| Idempotent re-run | detected as a no-op, no push |
| Target branch does not exist yet | created at the tag commit |
| Empty ref | exits non-zero with the intended message |
| Unresolvable ref | exits non-zero |
| Stale lease, simulating a concurrent update | push rejected, not forced |

The test is not committed: this repository has no test harness for workflows, and a test nothing runs is worse than none. It is reproducible from the description above, and wiring up workflow testing would be its own change.

## Risk / rollout notes

**Issue:** #384 — merge-commit strategy 409s against a linear-history ruleset on main
**Classification:** `bug` — recurs on every release for affected consumers, and the second defect delivered wrong content silently.
**Specialist:** `nolte-shared:cicd-pipeline-design`.

### The first run rewrites history on the presentation branch

This repository's `master` carries synthetic merge commits that never existed on `develop`, and `master` is **not an ancestor of `develop`**. The first reset discards them. They are artefacts of the mechanism being removed and nothing references them, but it is a non-fast-forward update and is called out here rather than discovered.

Consumers see the same on their next release. The presentation branch is documented as automatically refreshed and not a place to commit to; anyone holding local commits there must move them first.

### Not verifiable in this pull request

No workflow here calls this reusable in a pull-request context — it fires on `release: published`. The shell logic is covered by the tests above; the **wiring** (token, permissions, the `github.event.release.tag_name` expression) is first exercised on the next real release. That release is v2.0.0, which is why #394 sequences this change ahead of it.

**Deliberately not changed:** the job's display name still reads `Publish the the Release to Master`, typo included. It is a check context name, and renaming it would silently invalidate any consumer's branch protection that lists it — precisely the class of silent failure #387 is about. Worth fixing once that verification exists.

**Rollback:** revert the commit; the previous merge behaviour returns.
