### PR TITLE
fix(workflows): reference own reusables by local path, not @develop

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -49,7 +49,7 @@ jobs:
     permissions:
       contents: write # squash-merges the PR
       pull-requests: write # reads and updates PR state
-    uses: nolte/gh-plumbing/.github/workflows/reusable-automerge.yaml@develop
+    uses: ./.github/workflows/reusable-automerge.yaml
     with:
       app-id: ${{ vars.PORTFOLIO_APP_ID }}
     secrets:

--- a/.github/workflows/build-static-tests.yaml
+++ b/.github/workflows/build-static-tests.yaml
@@ -26,18 +26,28 @@ concurrency:
 # configuration only -- no application code and no build artifact -- so the
 # canonical test and package stages have nothing to run and are left out
 # deliberately. The four jobs below are the lint, docs, and securing stages.
+#
+# The jobs reference their reusables by LOCAL PATH, not by `nolte/gh-plumbing/
+# ...@<ref>`. A local path resolves against the current commit, so a pull
+# request that changes a reusable is verified by its own checks. With `@develop`
+# these checks ran develop's copy instead: a pull request could go green on all
+# contexts having executed none of its own changes, and nothing in the output
+# said so. See ADR-001's sibling decision on issue #392.
+#
+# Consumers cannot copy this form -- the file lives in another repository. The
+# consumer pattern is `@<tag>` and is documented under docs/*/workflows/.
 jobs:
   static:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@develop
+    uses: ./.github/workflows/reusable-pre-commit.yaml
   docs:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-mkdocs-build.yaml@develop
+    uses: ./.github/workflows/reusable-mkdocs-build.yaml
   security:
     permissions:
       contents: read
       security-events: write # reusable-trivy uploads SARIF to the Security tab
       actions: read # required by upload-sarif on private repositories
-    uses: nolte/gh-plumbing/.github/workflows/reusable-trivy.yaml@develop
+    uses: ./.github/workflows/reusable-trivy.yaml
   chain-bench:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-chain-bench.yaml@develop
+    uses: ./.github/workflows/reusable-chain-bench.yaml
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -8,4 +8,4 @@ permissions:
 
 jobs:
   dependency-review:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-dependency-review.yaml@develop
+    uses: ./.github/workflows/reusable-dependency-review.yaml

--- a/.github/workflows/release-cd-deliver-docs.yml
+++ b/.github/workflows/release-cd-deliver-docs.yml
@@ -27,7 +27,7 @@ jobs:
   publish_docs:
     permissions:
       contents: write # the called workflow pushes to gh-pages
-    uses: nolte/gh-plumbing/.github/workflows/reusable-mkdocs.yaml@develop
+    uses: ./.github/workflows/reusable-mkdocs.yaml
     with:
       app-id: ${{ vars.PORTFOLIO_APP_ID }}
     secrets:

--- a/.github/workflows/release-cd-refresh-master.yml
+++ b/.github/workflows/release-cd-refresh-master.yml
@@ -37,7 +37,7 @@ jobs:
   refresh_presentation_branch:
     permissions:
       contents: write # the called workflow pushes to the presentation branch
-    uses: nolte/gh-plumbing/.github/workflows/reusable-release-cd-refresh-master.yml@develop
+    uses: ./.github/workflows/reusable-release-cd-refresh-master.yml
     with:
       # github.event.release.tag_name, not github.event.ref: the release
       # payload carries no top-level `ref`, so the old expression resolved

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -29,7 +29,7 @@ jobs:
     permissions:
       contents: write # the called workflow edits the release draft
       pull-requests: read # release-drafter categorises merged PRs
-    uses: nolte/gh-plumbing/.github/workflows/reusable-release-drafter.yml@develop
+    uses: ./.github/workflows/reusable-release-drafter.yml
     with:
       app-id: ${{ vars.PORTFOLIO_APP_ID }}
     secrets:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -36,7 +36,7 @@ jobs:
   publish:
     permissions:
       contents: write # the called workflow flips the draft to published
-    uses: nolte/gh-plumbing/.github/workflows/reusable-release-publish.yml@develop
+    uses: ./.github/workflows/reusable-release-publish.yml
     with:
       tag: ${{ inputs.tag }}
       dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/reusable-hacs-validate.yaml
+++ b/.github/workflows/reusable-hacs-validate.yaml
@@ -14,7 +14,7 @@ name: Reusable — HACS Validate
 #
 #   jobs:
 #     validate:
-#       uses: nolte/gh-plumbing/.github/workflows/reusable-hacs-validate.yaml@develop
+#       uses: ./.github/workflows/reusable-hacs-validate.yaml
 
 on:
   workflow_call:

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -8,4 +8,4 @@ permissions:
 
 jobs:
   spelling:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-spelling-vale.yaml@develop
+    uses: ./.github/workflows/reusable-spelling-vale.yaml

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -14,6 +14,6 @@ jobs:
     permissions:
       issues: write # the called workflow labels and closes stale issues
       pull-requests: write # ... and stale PRs
-    uses: nolte/gh-plumbing/.github/workflows/reusable-stale.yaml@develop
+    uses: ./.github/workflows/reusable-stale.yaml
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/de/workflows/index.md
+++ b/docs/de/workflows/index.md
@@ -17,10 +17,11 @@ uses: nolte/gh-plumbing/.github/workflows/reusable-<name>.yaml@<tag>
     auf, worauf der Branch zur Laufzeit zeigt — eine Änderung hier erreicht
     deine CI sofort und ungeprüft.
 
-    Die Wrapper-Workflows dieses Repositories nutzen weiterhin `@develop`. Das
-    ist bewusstes Dogfooding des unveröffentlichten Stands, wird
-    [separat verfolgt](https://github.com/nolte/gh-plumbing/issues/392) und ist
-    kein Muster zum Nachbauen.
+    Die Wrapper-Workflows dieses Repositories nutzen eine lokale Pfadangabe,
+    etwa `uses: ./.github/workflows/reusable-trivy.yaml`. Diese Form löst gegen
+    den aktuellen Commit auf, ein Pull Request hier testet also die Workflows,
+    die er ändert. Für Consumer ist sie nicht nutzbar, weil die Datei in einem
+    anderen Repository liegt.
 
 ---
 

--- a/docs/en/workflows/index.md
+++ b/docs/en/workflows/index.md
@@ -17,10 +17,10 @@ uses: nolte/gh-plumbing/.github/workflows/reusable-<name>.yaml@<tag>
     reference resolves to whatever that branch points at when your workflow
     runs, so a change here reaches your CI immediately and without review.
 
-    This repository's own wrapper workflows still use `@develop`. That is
-    deliberate dog-fooding of the unreleased state, is
-    [tracked separately](https://github.com/nolte/gh-plumbing/issues/392), and
-    is not a pattern to copy.
+    This repository's own wrapper workflows use a local path, such as
+    `uses: ./.github/workflows/reusable-trivy.yaml`. That form resolves against
+    the current commit, so a pull request here tests the workflows it changes.
+    A consumer can't use it, because the file lives in another repository.
 
 ---
 


### PR DESCRIPTION
## Summary

The nine wrapper workflows referenced this repository's own reusables as `nolte/gh-plumbing/.github/workflows/reusable-*.yaml@develop`. They now use a local path:

```yaml
uses: ./.github/workflows/reusable-trivy.yaml
```

A local path resolves against the **current commit**. §A's requirement is satisfied by removing the reference class rather than by carving out an exception for it — a rule that needs an exemption for its own author's repository is a weaker rule.

Closes #392

## Why this matters more than spec conformance

`@develop` resolves against the branch, **not the pull-request head**. Every check on a pull request that changed a reusable therefore ran `develop`'s copy.

Measured in this batch rather than argued: **three pull requests** (#389, #397, #400) each needed a temporary retarget-then-revert commit pair to get a real signal. On #389 the first run went green on all eight checks having executed entirely unchanged code. The only evidence was one line in the security job's log:

```text
Download action repository 'aquasecurity/trivy-action@master'
```

`@master` was the reference that pull request existed to remove. Green checks that verify nothing are worse than absent checks, because they read as evidence in review.

With local paths, a pull request touching a reusable is verified by its own checks, and this one is the first demonstration.

## Changes

- All 12 `uses:` references across the nine wrappers converted to local paths.
- `build-static-tests.yaml` carries a comment explaining the form and naming the failure it prevents, so a future edit does not "restore consistency" by putting `@develop` back.
- The documentation admonition added in #402 is corrected. It said the wrappers still used `@develop` as deliberate dog-fooding, which stops being true with this change. Both locales now explain the local-path form and why a consumer cannot use it.

## Linked issues

Closes #392 — half (a), the consumer documentation, landed in #402.

## Testing

- `pre-commit run --all-files`, `mkdocs build --strict`, and `vale --minAlertLevel=error` on the changed page — all green.
- All 30 workflow files parsed.

**This pull request is its own test.** If the local paths work, the checks below ran the reusables *from this branch*. Confirm in the run log that each reusable resolved to this pull request's SHA rather than to `develop` — that is the whole claim, and it is visible in the `Uses:` line of each job.

## Risk / rollout notes

**Issue:** #392 — Consumer docs instruct @develop, propagating an unpinned reusable-workflow reference portfolio-wide
**Classification:** `refactor` with a `security` dimension (§A conformance) and a `test-coverage` dimension (the verification gap).
**Specialist:** `nolte-shared:cicd-pipeline-design`.

**No consumer impact.** Only this repository's own wrappers change. Consumers reference the reusables by tag and are untouched.

**What is given up, stated plainly.** The wrappers stop being a copy-pasteable template, because a consumer cannot write `./`. That was a genuine second role they played and it is surrendered on purpose: documentation is where the consumer pattern belongs, and #402 made those pages correct. A wrapper that teaches by example while being unable to test itself was serving the reader at the expense of the code.

**The retarget dance is now unnecessary.** Any future pull request touching a `reusable-*` file is verified by its own checks. That removes a manual step which, on its first use, silently failed to be applied at all.

**Rollback:** revert; `@develop` returns along with the verification gap.
