### PR TITLE
feat(audit): compare declared branch protection against what is enforced

### DIFF
--- a/.github/workflows/portfolio-branch-protection-audit.yml
+++ b/.github/workflows/portfolio-branch-protection-audit.yml
@@ -1,0 +1,49 @@
+name: Portfolio — Branch Protection Audit
+
+# Runs the declared-versus-enforced comparison across the portfolio on a
+# schedule. Scheduled rather than pull-request-triggered because the failure it
+# detects is drift over time: protection that was applied once can stop being
+# applied, and no commit marks the moment it does.
+#
+# A red run here means some repository declares protection GitHub is not
+# enforcing. Treat it as a real finding, not as flakiness -- see issue #387,
+# where the same condition went unnoticed long enough that a merge which should
+# have been blocked went through.
+
+on:
+  schedule:
+    # Mondays, early. Weekly is enough for configuration drift, and a daily
+    # run would train the reader to ignore it.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+    inputs:
+      repos:
+        description: Space-separated owner/name list. Empty surveys the whole portfolio.
+        required: false
+        type: string
+        default: ""
+      branch:
+        description: Branch whose protection is compared.
+        required: false
+        type: string
+        default: develop
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/reusable-branch-protection-audit.yaml
+    with:
+      repos: ${{ inputs.repos || '' }}
+      branch: ${{ inputs.branch || 'develop' }}
+      # Reading protection across the portfolio needs more reach than this
+      # workflow's own GITHUB_TOKEN has. Without the App the audit reports
+      # every other repository as unreadable, which it flags rather than
+      # mistaking for "unprotected".
+      app-id: ${{ vars.PORTFOLIO_APP_ID }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+      app-private-key: ${{ secrets.PORTFOLIO_APP_PRIVATE_KEY }}

--- a/.github/workflows/reusable-branch-protection-audit.yaml
+++ b/.github/workflows/reusable-branch-protection-audit.yaml
@@ -1,0 +1,100 @@
+name: Reusable — Branch Protection Audit
+
+# Compares branch protection declared in `.github/settings.yml` against what
+# GitHub actually enforces, and fails when they differ.
+#
+# This exists because that gap is invisible: no error, no log, no failed check.
+# The declaration looks correct, the Probot Settings App reports nothing, and
+# the protection is absent. Nobody notices until a merge that should have been
+# blocked goes through. See issue #387 and ADR-002.
+#
+# The audit is read-only. It never repairs protection -- deciding what the
+# commons should declare is a separate question that this data is meant to
+# inform, not pre-empt.
+
+on:
+  workflow_call:
+    inputs:
+      repos:
+        description: |
+          Space-separated `owner/name` list to survey. Empty (the default)
+          surveys every non-archived, non-fork repository of `owner`.
+        required: false
+        type: string
+        default: ""
+      owner:
+        description: Account whose repositories are surveyed when `repos` is empty.
+        required: false
+        type: string
+        default: nolte
+      branch:
+        description: Branch whose protection is compared.
+        required: false
+        type: string
+        default: develop
+      app-id:
+        description: |
+          Numeric GitHub App ID. When set, the audit runs under a short-lived
+          installation token, which is the only way to read protection across
+          repositories the workflow's own `GITHUB_TOKEN` cannot reach. When
+          empty, it falls through to `secrets.token` -- fine for a single-repo
+          audit, insufficient for a portfolio-wide one.
+        required: false
+        type: string
+        default: ""
+    secrets:
+      token:
+        required: true
+      app-private-key:
+        description: PEM key for `inputs.app-id`. Required when it is set.
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: branch-protection-audit-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: Branch Protection Audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Mint App installation token
+        id: app-token
+        if: ${{ inputs.app-id != '' }}
+        # Not continue-on-error, unlike the release workflows: there the
+        # fallback still does useful work, whereas here a degraded token makes
+        # every repository look unreadable or unprotected. A wrong answer is
+        # worse than no answer for an audit.
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ inputs.app-id }}
+          private-key: ${{ secrets.app-private-key }}
+          owner: ${{ inputs.owner }}
+
+      - name: Checkout sources
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.14"
+
+      - name: Install PyYAML
+        run: pip install --require-hashes --no-deps -r scripts/requirements-audit.txt
+
+      - name: Compare declared against enforced
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.token }}
+          REPOS: ${{ inputs.repos }}
+          OWNER: ${{ inputs.owner }}
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC2086  # REPOS is a deliberate word-split list
+          python3 scripts/branch_protection_audit.py \
+            --owner "${OWNER}" --branch "${BRANCH}" ${REPOS}

--- a/scripts/branch_protection_audit.py
+++ b/scripts/branch_protection_audit.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Compare declared branch protection against what GitHub actually enforces.
+
+Branch protection declared in `.github/settings.yml` is frequently not applied.
+The declaration looks correct, the Probot Settings App reports nothing, and the
+protection is absent. Nobody notices until a merge that should have been
+blocked goes through -- see issue #387.
+
+The defining property of that fault is invisibility: no error, no log, no
+failed check. This script makes it visible, and fails when declared protection
+is missing so a scheduled run cannot pass silently.
+
+It reports *per declared context* rather than diffing sets, because the
+interesting case in practice is a partial application: `gh-plumbing` declares
+three required contexts and GitHub enforces one.
+
+Reads only. Requires a token with `repo` scope (administration read) for every
+repository surveyed; repositories it cannot read are reported as such rather
+than skipped, since an unreadable repository is indistinguishable from an
+unprotected one otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+API = "https://api.github.com"
+COMMONS_REPO = "nolte/gh-plumbing"
+COMMONS_PATH = ".github/commons-settings.yml"
+
+
+class Forbidden(Exception):
+    """The token may not read this resource."""
+
+
+def api(path: str, token: str):
+    """GET a JSON endpoint.
+
+    Returns None on 404. Raises Forbidden on 403 so a permission gap is never
+    mistaken for an absent protection rule -- with a token that cannot read
+    administration, every repository would otherwise look unprotected, which is
+    the most dangerous possible false negative for this script.
+    """
+    req = urllib.request.Request(
+        f"{API}/{path}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "gh-plumbing-branch-protection-audit",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.load(resp)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        if exc.code == 403:
+            raise Forbidden(path) from exc
+        if exc.code == 401:
+            raise SystemExit(
+                "::error::the token was rejected (401). A scheduled audit that "
+                "cannot authenticate must fail loudly, not report an empty "
+                "portfolio as healthy."
+            )
+        raise
+
+
+def read_yaml_file(repo: str, path: str, token: str):
+    """Fetch and parse a YAML file from a repository's default branch."""
+    payload = api(f"repos/{repo}/contents/{path}", token)
+    if payload is None:
+        return None
+    import yaml  # imported late so --help works without the dependency
+
+    return yaml.safe_load(base64.b64decode(payload["content"]).decode())
+
+
+def declared_contexts(settings, commons, branch: str):
+    """Resolve the contexts a repository declares for one branch.
+
+    The Probot Settings App merges `branches:` entries by `name`, so a per-repo
+    entry overrides the commons entry of the same name field by field.
+    """
+    def contexts_from(doc):
+        if not isinstance(doc, dict):
+            return None
+        for entry in doc.get("branches") or []:
+            if entry.get("name") != branch:
+                continue
+            checks = (entry.get("protection") or {}).get("required_status_checks")
+            if checks is None:
+                continue
+            return list(checks.get("contexts") or [])
+        return None
+
+    own = contexts_from(settings)
+    if own is not None:
+        return own
+    # Only fall through to the commons when the repository extends them.
+    if settings and settings.get("_extends"):
+        return contexts_from(commons) or []
+    return []
+
+
+def audit_repo(repo: str, branch: str, commons, token: str) -> dict:
+    result = {"repo": repo, "branch": branch, "notes": []}
+
+    try:
+        settings = read_yaml_file(repo, ".github/settings.yml", token)
+    except Forbidden:
+        result["status"] = "unreadable"
+        result["notes"].append("the token may not read this repository's contents")
+        return result
+    if settings is None:
+        result["status"] = "no-settings"
+        result["notes"].append("no .github/settings.yml")
+        return result
+
+    result["extends"] = settings.get("_extends") or "(none)"
+    declared = declared_contexts(settings, commons, branch)
+    result["declared"] = declared
+
+    try:
+        protection = api(f"repos/{repo}/branches/{branch}/protection", token)
+    except Forbidden:
+        result["status"] = "unreadable"
+        result["live"] = []
+        result["notes"].append(
+            "the token may not read branch protection here; this is NOT evidence "
+            "that the branch is unprotected"
+        )
+        return result
+    if protection is None:
+        result["status"] = "unprotected" if declared else "ok"
+        result["live"] = []
+        if declared:
+            result["notes"].append(
+                f"{len(declared)} context(s) declared, branch has no protection at all"
+            )
+        return result
+
+    checks = protection.get("required_status_checks") or {}
+    live = list(checks.get("contexts") or [])
+    result["live"] = live
+    result["strict"] = checks.get("strict")
+    result["enforce_admins"] = (protection.get("enforce_admins") or {}).get("enabled")
+    result["restrictions"] = "present" if protection.get("restrictions") else "null"
+
+    # Distinguish "the commons were applied and something was dropped" from
+    # "the commons were never applied". The commons declare enforce_admins and
+    # strict for develop; a repository that extends them and reports neither is
+    # a different fault from one that reports both and is missing a context.
+    if settings.get("_extends") and isinstance(commons, dict):
+        for entry in commons.get("branches") or []:
+            if entry.get("name") != branch:
+                continue
+            wanted = entry.get("protection") or {}
+            if wanted.get("enforce_admins") and not result["enforce_admins"]:
+                result["notes"].append(
+                    "extends the commons but `enforce_admins` is not enforced -- "
+                    "the commons block looks unapplied, not merely incomplete"
+                )
+            break
+
+    missing = [c for c in declared if c not in live]
+    extra = [c for c in live if c not in declared]
+    result["missing"] = missing
+    result["extra"] = extra
+
+    if missing:
+        result["status"] = "drift"
+        result["notes"].append(f"declared but not enforced: {', '.join(missing)}")
+        # The observation from #387: on gh-plumbing the only context that
+        # applied was the first declared one. Flag the pattern so a second
+        # sample either confirms it or kills it.
+        if declared and live and declared[0] in live and all(
+            c not in live for c in declared[1:]
+        ):
+            result["notes"].append(
+                "only the FIRST declared context is enforced -- matches the "
+                "gh-plumbing pattern"
+            )
+    else:
+        result["status"] = "ok"
+    if extra:
+        result["notes"].append(f"enforced but not declared: {', '.join(extra)}")
+    return result
+
+
+def render(results: list[dict]) -> str:
+    order = {"drift": 0, "unprotected": 1, "unreadable": 2, "no-settings": 3, "ok": 4}
+    results = sorted(results, key=lambda r: (order.get(r["status"], 9), r["repo"]))
+
+    lines = ["# Branch protection: declared versus enforced", ""]
+    drift = [r for r in results if r["status"] in ("drift", "unprotected", "unreadable")]
+    lines.append(
+        f"**{len(drift)} of {len(results)}** surveyed repositories do not enforce "
+        "what they declare, or could not be read."
+    )
+    lines.append("")
+    lines.append("| Repository | Branch | Declared | Enforced | Status |")
+    lines.append("|---|---|---|---:|---|")
+    for r in results:
+        lines.append(
+            f"| `{r['repo']}` | `{r['branch']}` | {len(r.get('declared', []))} "
+            f"| {len(r.get('live', []))} | {r['status']} |"
+        )
+
+    detail = [r for r in results if r["notes"]]
+    if detail:
+        lines += ["", "## Detail", ""]
+        for r in detail:
+            lines.append(f"### `{r['repo']}`")
+            lines.append("")
+            for note in r["notes"]:
+                lines.append(f"- {note}")
+            if r.get("declared"):
+                lines.append(f"- declared: `{'`, `'.join(r['declared'])}`")
+            if r.get("live"):
+                lines.append(f"- enforced: `{'`, `'.join(r['live'])}`")
+            if r.get("restrictions"):
+                lines.append(
+                    f"- `restrictions`: {r['restrictions']}, "
+                    f"`enforce_admins`: {r.get('enforce_admins')}, "
+                    f"`strict`: {r.get('strict')}"
+                )
+            lines.append(f"- `_extends`: `{r.get('extends', '(unknown)')}`")
+            lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("repos", nargs="*", help="owner/name; default: every non-archived nolte repo")
+    parser.add_argument("--branch", default="develop")
+    parser.add_argument("--owner", default="nolte")
+    parser.add_argument(
+        "--exit-zero",
+        action="store_true",
+        help="report drift without failing; for an initial survey, not for the schedule",
+    )
+    args = parser.parse_args()
+
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("::error::GH_TOKEN or GITHUB_TOKEN must be set", file=sys.stderr)
+        return 2
+
+    repos = args.repos
+    if not repos:
+        repos = []
+        page = 1
+        while True:
+            batch = api(f"users/{args.owner}/repos?per_page=100&page={page}", token) or []
+            if not batch:
+                break
+            repos += [
+                r["full_name"]
+                for r in batch
+                # Forks carry upstream's configuration and would drown the
+                # signal; archived repositories cannot be fixed.
+                if not r["archived"] and not r["fork"]
+            ]
+            page += 1
+
+    commons = read_yaml_file(COMMONS_REPO, COMMONS_PATH, token)
+
+    results = [audit_repo(repo, args.branch, commons, token) for repo in repos]
+    report = render(results)
+    print(report)
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as handle:
+            handle.write(report + "\n")
+
+    drift = [r for r in results if r["status"] in ("drift", "unprotected", "unreadable")]
+    if drift and not args.exit_zero:
+        print(
+            f"::error::{len(drift)} repositories do not enforce their declared "
+            "branch protection",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/requirements-audit.txt
+++ b/scripts/requirements-audit.txt
@@ -1,0 +1,10 @@
+# Dependencies for scripts/branch_protection_audit.py.
+#
+# Kept separate from requirements-dev.txt: that file installs the MkDocs
+# toolchain, and the audit workflow has no reason to pull it in.
+#
+# Version-pinned rather than hash-pinned, matching requirements-dev.txt.
+# A hash pin would name one platform-specific wheel and break whenever the
+# runner's Python minor version changes; Renovate bumps the version here as a
+# reviewable pull request either way.
+PyYAML==6.0.3


### PR DESCRIPTION
## Summary

Branch protection declared in `.github/settings.yml` is frequently not applied. The declaration looks correct, the Settings App reports nothing, and the protection is absent. Nobody notices until a merge that should have been blocked goes through.

This adds the comparison that makes it visible, and a weekly schedule so drift cannot accumulate unseen. Decision recorded in [ADR-002](https://nolte.github.io/gh-plumbing/decisions/adr-002-branch-protection-verification/): **verification first, cause second** — removing `restrictions` from the commons would have closed this repository's case and left four unexplained ones looking solved.

Refs #387 — the audit is the deliverable; what to change in the commons is decided from its output.

## What the first run found

**4 of 20** non-archived, non-fork repositories do not enforce what they declare, in **three distinct shapes**. This matters: it is not one cause.

| Repository | Declared | Enforced | Shape |
|---|---|---:|---|
| `gh-plumbing` | 3 | 1 | only the **first** declared context applies |
| `claude-shared` | 4 | 3 | one context missing, **and the commons look unapplied entirely** |
| `claude-home-assistant` | 3 | 0 | no protection at all |
| `claude-reachy-mini` | 3 | 0 | no protection at all |

Two hypotheses from the issue can now be narrowed:

**`restrictions` does not explain the current state.** `gh-plumbing` reports `restrictions: null` live, with `strict: true` and `enforce_admins: true`. The update is not being dropped wholesale — one context applies and two do not.

**"The context does not exist as a check run yet" looks insufficient.** `docs / MkDocs Build` has been declared since 2026-06-14, runs on every push, and reports under exactly that name. It has still never been applied.

**A shape not in the original candidate list:** on `gh-plumbing` the only enforced context is the **first** declared one. The script flags that pattern explicitly so a second sample either confirms or kills it.

**`claude-shared` is a different fault from the others.** It reports `enforce_admins: false` and `strict: false` while extending commons that declare both — so its live protection looks manually configured rather than partially synced. It is also the only repository pinning `_extends` to a tag (`@v1.1.19`).

## Changes

- `scripts/branch_protection_audit.py` — resolves declared contexts through `_extends`, reads live protection, and reports **per declared context** rather than diffing sets. Exits non-zero on drift.
- `reusable-branch-protection-audit.yaml` — so a consumer can audit itself, following the house pattern.
- `portfolio-branch-protection-audit.yml` — weekly, plus manual dispatch.
- `scripts/requirements-audit.txt` — PyYAML, kept out of the MkDocs requirements.

## Testing

Run against the live portfolio; the table above is its actual output. Exit codes verified: `0` on a clean repository, `1` on a drifting one, `1` on a rejected token.

**Two failure modes that would make this dangerous were handled explicitly.** A `403` is reported as `unreadable`, never as `unprotected` — with a token that cannot read administration, every repository would otherwise look unprotected, which is the worst possible false negative here. A `401` exits with a clear message rather than a traceback, because a scheduled audit that cannot authenticate must not report an empty portfolio as healthy.

`actionlint` clean, `pre-commit` green.

## Risk / rollout notes

**Issue:** #387 · **Classification:** `infra` with a `security` dimension.
**Specialist:** no matching specialised agent — generalist remediation.

**This does not fix anything.** It reports. Deliberately: the issue asks for all drift shapes to be explained before the commons change, and the data above shows three different ones. A `restrictions` fix would address at most one.

**The schedule will be red from its first run** until the underlying causes are fixed. That is intended — a green audit over a broken portfolio is the state this replaces — but it means the first weekly run is a finding, not a regression.

**Unverified: whether the App token has the reach it needs.** `PORTFOLIO_APP_ID` is used to read protection across repositories, and whether the App holds `administration: read` everywhere is itself one of the issue's open questions. If it does not, the audit reports those repositories as `unreadable` and fails — which is the correct behaviour and also the answer to that question.

**Rollback:** delete the two workflows and the script; nothing depends on them.
