### PR TITLE
feat(release-drafter): exclude exp/ branches from release notes

### DIFF
--- a/.github/commons-release-drafter.yml
+++ b/.github/commons-release-drafter.yml
@@ -66,9 +66,16 @@ autolabeler:
   - label: "release"
     title:
       - '/^chore\(release\):/'
+  # Exploratory work is not something a consumer shipped, so it does not belong
+  # in the changelog. Without this pairing an `exp/` pull request landed
+  # uncategorised in the "shipped" section, which reads as a delivered change.
+  - label: "experimental"
+    branch:
+      - '/^exp\//'
 
 exclude-labels:
   - "release"
+  - "experimental"
 
 template: |
   ## Changes

--- a/.github/commons-settings.yml
+++ b/.github/commons-settings.yml
@@ -150,6 +150,10 @@ labels:
     color: "#cccccc"
     description: Auto-applied by actions/stale to inactive issues and pull requests.
 
+  - name: experimental
+    color: "#d4c5f9"
+    description: Exploratory work from an `exp/` branch. Excluded from release notes.
+
 # <!--td-commons-settings-labels-end-->
 
 branches:

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -7,7 +7,12 @@
 # file as well (a comment touch is enough) so the App re-runs the merge.
 # Tracked by https://github.com/nolte/gh-plumbing/issues/331.
 #
-# Last propagation: 2026-08-01 — add the `actionlint / Workflow Lint` required
+# Last propagation: 2026-08-01 (second) — propagate the new `experimental`
+# label from commons-settings.yml so the Settings App creates it portfolio-wide.
+# The `exp/` autolabeler in commons-release-drafter.yml is inert until the label
+# exists in the repository it fires in.
+#
+# Previous propagation: 2026-08-01 — add the `actionlint / Workflow Lint` required
 # context (issue #398). Verify the result through the API rather than the
 # settings page: issue #387 found that five of nine consumers silently drift
 # between declared and live protection, so a declaration landing here is not


### PR DESCRIPTION
## Summary

`commons-release-drafter.yml` had no autolabeler for the `exp/` branch prefix and no matching `exclude-labels` entry, so an `exp/` pull request landed **uncategorised in the "shipped" section** of the release notes — reading as a delivered change when it was exploratory work.

This is the one item pulled forward out of #386; the rest goes to the roadmap per [ADR-004](https://nolte.github.io/gh-plumbing/decisions/adr-004-spec-drift-routing/).

Refs #386

## Changes

**`commons-release-drafter.yml`** gains the autolabeler and the exclusion:

```yaml
  - label: "experimental"
    branch:
      - '/^exp\//'

exclude-labels:
  - "release"
  - "experimental"
```

**`commons-settings.yml` gains the `experimental` label.** The original write-up did not mention this, and without it the change would have been inert: release-drafter's autolabeler applies a label, and applying one that does not exist in the target repository silently does nothing. The pairing only works if both halves ship.

**`.github/settings.yml` is touched** so the Settings App re-runs the `_extends` merge and creates the label portfolio-wide. That file's own comment documents this requirement — commons changes do not propagate on their own.

## Linked issues

Refs #386 — this closes the fourth cluster only. Clusters 1 to 3 (the PR-lint reusable, five release-publish hardening items, and two pre-release gates) go to `roadmap-plan`, and #386 stays open until that item exists.

## Testing

- All three YAML files parsed; the autolabeler and `exclude-labels` asserted from the parsed document rather than read back by eye.
- The label description is 68 characters, under the 100-character GitHub API limit the pre-commit hook guards. That limit fails **silently** at the API, so it is checked rather than assumed.
- `pre-commit run --all-files` and `actionlint` — green.

**Not verifiable before merge, and stated rather than glossed:** whether the label actually gets created, and whether the autolabeler fires. The Settings App applies labels after the merge, and the autolabeler needs a real `exp/` pull request. #387's audit found that five of nine repositories silently drift between declared and live settings, so a declaration landing here is **not** evidence that it applied. Verify with `gh label list` after the sync.

## Risk / rollout notes

**Issue:** #386 — Spec-drift Q2, cluster 4 · **Classification:** `chore` (portfolio configuration).
**Specialist:** no matching specialised agent — generalist remediation.

**Portfolio-wide.** Every repository extending the commons gets the label and the rule on the next sync. Existing `exp/` pull requests are not relabelled retroactively; the autolabeler fires on new events.

**One behaviour worth knowing:** the exclusion removes `experimental` pull requests from release notes entirely, rather than moving them to a separate section. That is the intent — exploratory work is not something a consumer shipped — but it means a change that started on an `exp/` branch and turned out to be real will need its label removed before the release.

**Rollback:** revert; the label stays created but stops being applied.
