### PR TITLE
fix(vale): track the repository vocabulary and make the spelling check fail

### DIFF
--- a/.github/styles/config/vocabularies/gh-plumbing/accept.txt
+++ b/.github/styles/config/vocabularies/gh-plumbing/accept.txt
@@ -1,0 +1,10 @@
+# Repository-local Vale vocabulary. Tracked in git; `.gitignore` un-ignores this
+# one subtree of `.github/styles/`, which `vale sync` otherwise owns.
+#
+# Add a term here only when it is a real technical identifier the shipped
+# vocabularies miss. A term useful beyond this repository belongs upstream in
+# nolte/vale-style instead -- `vocab-drift-audit` checks for entries that have
+# since been accepted there and can be dropped.
+#
+# ruleset: GitHub's own product term for a branch or tag rule set.
+[Rr]uleset

--- a/.github/workflows/reusable-spelling-vale.yaml
+++ b/.github/workflows/reusable-spelling-vale.yaml
@@ -16,3 +16,19 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: errata-ai/vale-action@85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a # v2.1.2
+        with:
+          # The action defaults to `fail_on_error: false`, so this check was
+          # green by construction: #403 introduced three errors on added lines
+          # and it still passed. A signal that reads as a gate and is not one is
+          # worse than no signal, which is the same conclusion #398 reached for
+          # workflow validity.
+          fail_on_error: true
+          # `added` is the action's default and is kept deliberately, unlike the
+          # actionlint reusable where `nofilter` is right. Prose findings are
+          # noisier than syntax errors, and existing documentation debt should
+          # not block an unrelated pull request -- an author is answerable for
+          # the lines they wrote.
+          filter_mode: added
+          # Errors only. Warnings and suggestions stay visible as annotations
+          # without failing the run.
+          level: error

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,16 @@ site
 
 .github/styles/*
 !.github/styles/.keep
+# `vale sync` writes the downloaded style packages here, so the directory stays
+# ignored -- except this repository's own vocabulary, which is source and has to
+# be tracked. It previously was not, so an entry added to accept.txt was
+# discarded at commit time without a word (issue #409). Verified that `vale sync`
+# leaves this subtree alone.
+!.github/styles/config
+.github/styles/config/*
+!.github/styles/config/vocabularies
+.github/styles/config/vocabularies/*
+!.github/styles/config/vocabularies/gh-plumbing
 .task
 .claude/
 

--- a/.vale.ini
+++ b/.vale.ini
@@ -3,6 +3,12 @@ MinAlertLevel = suggestion
 
 Packages = Microsoft, RedHat, https://github.com/nolte/vale-style/releases/download/v0.1.3/nolte-styles.zip
 
+# `technical` ships with the nolte-styles package; `gh-plumbing` is this
+# repository's own, tracked in git. Both are listed because Vocab replaces
+# rather than extends -- naming only the local one would silently drop every
+# word the package accepts.
+Vocab = technical, gh-plumbing
+
 IgnoredScopes = code,tt, em
 
 [*.md]

--- a/docs/en/workflows/container.md
+++ b/docs/en/workflows/container.md
@@ -117,6 +117,3 @@ reference. Deployments consume the index digest or a `type=semver` tag.
 digest and no attestation. The lint and the build run independently, so one
 run reports both a `Dockerfile` finding and a build failure rather than hiding
 the second behind the first.
-
-<!-- gate probe -->
-This sentance has a deliberate speling error to probe the gate.

--- a/docs/en/workflows/container.md
+++ b/docs/en/workflows/container.md
@@ -117,3 +117,6 @@ reference. Deployments consume the index digest or a `type=semver` tag.
 digest and no attestation. The lint and the build run independently, so one
 run reports both a `Dockerfile` finding and a build failure rather than hiding
 the second behind the first.
+
+<!-- gate probe -->
+This sentance has a deliberate speling error to probe the gate.


### PR DESCRIPTION
## Summary

Two connected problems, both making the prose gate weaker than it appeared.

**A repository-local Vale vocabulary could not exist.** `.gitignore` ignored all of `.github/styles/`, which is where the vocabulary lives, so any entry added there was discarded at commit time without a word. #403's body reports adding `[Rr]uleset` to `accept.txt` — **it was never committed**, and `docs/en/decisions/adr-001-presentation-branch-reset.md` has produced three `Vale.Spelling` errors on `develop` ever since.

**The check could not fail.** `errata-ai/vale-action` was called with no `with:` block, so it took `fail_on_error: false`. #403 introduced three errors on added lines and the check still passed. A signal that reads as a gate and is not one — the same shape #398 decided against for workflow validity.

Closes #409

## Changes

**The vocabulary is tracked**, in its own `gh-plumbing` directory, with only that subtree un-ignored. `.vale.ini` lists **both** it and the package's `technical` vocabulary, because `Vocab` replaces rather than extends — naming only the local one would have silently dropped every word `nolte-styles` accepts.

**The check fails on errors**, and every overridden default now carries its reasoning in the workflow instead of being implied by an action default nobody reads:

| Setting | Value | Why |
|---|---|---|
| `fail_on_error` | `true` | Otherwise the check is green by construction |
| `filter_mode` | `added` (the default, kept deliberately) | Prose findings are noisier than syntax errors, and existing documentation debt should not block an unrelated PR. An author is answerable for the lines they wrote. |
| `level` | `error` | Warnings and suggestions stay visible as annotations without failing the run |

This is deliberately **not** the choice made for `reusable-actionlint`, where `nofilter` is right: an invalid workflow file is invalid regardless of who last touched it, while a comma splice in a paragraph nobody edited is not this PR's problem.

## Linked issues

Closes #409

## Testing

Three assumptions were tested rather than assumed, because each would have failed silently:

- **Multi-value `Vocab` works.** Both vocabularies apply — probed with a word from each (`Taskfile` from the package, `ruleset` from the local one).
- **`vale sync` leaves the local subtree alone.** Ran it and confirmed `gh-plumbing/accept.txt` survives with its content intact. Had it been overwritten, the fix would have looked correct and decayed on the next sync.
- **The vocabulary is genuinely tracked now** — `git status` shows the file as added, which is precisely what #403 could not achieve.

`vale --minAlertLevel=error` over `docs/` and `README.md`: **0 errors in 40 files**, so ADR-001 is clean again. `actionlint` and `pre-commit` green.

**The gate was verified to actually gate.** A deliberate spelling error was pushed to this branch, `spelling / runner / vale` observed **red**, and the error then reverted. Both runs are in this PR's history — a green check proves the check ran, not that it can fail.

## Risk / rollout notes

**Issue:** #409 — Vale vocabulary is gitignored and the spelling check cannot fail
**Classification:** `bug` with a `docs` dimension.
**Specialist:** no matching specialised agent — generalist remediation. `prose-vale-curator` curates prose to pass Vale and extends vocabulary *in a repository that owns Vale source*; this is the wiring that makes such curation possible at all.

**Consumer impact is real.** `reusable-spelling-vale` now fails a pull request whose **added** lines carry Vale errors. Every consumer inherits that on the next bump. Previously the check was decorative, so some consumers may have accumulated findings they have never seen — those only surface on lines they newly touch, not retroactively.

**The vocabulary is repository-local by design.** A term useful beyond this repository belongs upstream in `nolte/vale-style`; the file says so, and `vocab-drift-audit` exists to catch entries that have since been accepted there. `ruleset` is a candidate for upstreaming — it is GitHub's own product term, not something specific to this repository.

**Rollback:** revert; the check goes back to advisory and the vocabulary stops being tracked.
