### PR TITLE
fix(audit): read rulesets, not just classic branch protection

### DIFF
--- a/scripts/branch_protection_audit.py
+++ b/scripts/branch_protection_audit.py
@@ -11,8 +11,19 @@ failed check. This script makes it visible, and fails when declared protection
 is missing so a scheduled run cannot pass silently.
 
 It reports *per declared context* rather than diffing sets, because the
-interesting case in practice is a partial application: `gh-plumbing` declares
-three required contexts and GitHub enforces one.
+interesting case in practice is partial application.
+
+Enforcement comes from TWO independent mechanisms and the union of both is what
+actually gates a merge:
+
+  * classic branch protection, which the Probot Settings App writes from
+    `.github/settings.yml`  -> /branches/{branch}/protection
+  * repository and organisation rulesets, which it does not touch
+    -> /rules/branches/{branch}
+
+Reading only the first is how the initial version of this script reported
+`docs / MkDocs Build` as unenforced on `gh-plumbing` when a ruleset had been
+enforcing it all along.
 
 Reads only. Requires a token with `repo` scope (administration read) for every
 repository surveyed; repositories it cannot read are reported as such rather
@@ -128,6 +139,29 @@ def audit_repo(repo: str, branch: str, commons, token: str) -> dict:
     declared = declared_contexts(settings, commons, branch)
     result["declared"] = declared
 
+    # Read rulesets FIRST. A repository with no classic branch protection can
+    # still be fully protected by one, so returning early on a 404 from the
+    # protection endpoint would report it as unprotected -- the most dangerous
+    # error an audit can make, because it sends someone to "fix" a repository
+    # that is correctly configured. nolte/claude-home-assistant is exactly that
+    # case, and the first version of this script got it wrong.
+    try:
+        rules = api(f"repos/{repo}/rules/branches/{branch}", token) or []
+    except Forbidden:
+        rules = []
+        result["notes"].append(
+            "the token may not read rulesets here; enforcement may be "
+            "under-reported"
+        )
+    ruleset_ctx = sorted({
+        c["context"]
+        for rule in rules
+        if rule.get("type") == "required_status_checks"
+        for c in (rule.get("parameters") or {}).get("required_status_checks") or []
+        if c.get("context")
+    })
+    result["ruleset"] = ruleset_ctx
+
     try:
         protection = api(f"repos/{repo}/branches/{branch}/protection", token)
     except Forbidden:
@@ -139,20 +173,42 @@ def audit_repo(repo: str, branch: str, commons, token: str) -> dict:
         )
         return result
     if protection is None:
-        result["status"] = "unprotected" if declared else "ok"
-        result["live"] = []
-        if declared:
+        result["classic"] = []
+        result["live"] = ruleset_ctx
+        missing = [c for c in declared if c not in ruleset_ctx]
+        if declared and not ruleset_ctx:
+            result["status"] = "unprotected"
             result["notes"].append(
-                f"{len(declared)} context(s) declared, branch has no protection at all"
+                f"{len(declared)} context(s) declared, and neither classic "
+                "protection nor a ruleset enforces anything"
             )
+        elif missing:
+            result["status"] = "drift"
+            result["notes"].append(
+                f"declared but not enforced: {', '.join(missing)}"
+            )
+            result["notes"].append(
+                "no classic branch protection; a ruleset enforces the rest"
+            )
+        else:
+            result["status"] = "ok"
+            if declared:
+                result["notes"].append(
+                    "no classic branch protection, but a ruleset enforces every "
+                    "declared context -- protected, just not by the Settings App"
+                )
         return result
 
     checks = protection.get("required_status_checks") or {}
-    live = list(checks.get("contexts") or [])
-    result["live"] = live
+    classic = list(checks.get("contexts") or [])
     result["strict"] = checks.get("strict")
     result["enforce_admins"] = (protection.get("enforce_admins") or {}).get("enabled")
     result["restrictions"] = "present" if protection.get("restrictions") else "null"
+
+    result["classic"] = classic
+    # The union gates the merge; either mechanism alone is an incomplete answer.
+    live = sorted(set(classic) | set(ruleset_ctx))
+    result["live"] = live
 
     # Distinguish "the commons were applied and something was dropped" from
     # "the commons were never applied". The commons declare enforce_admins and
@@ -178,16 +234,6 @@ def audit_repo(repo: str, branch: str, commons, token: str) -> dict:
     if missing:
         result["status"] = "drift"
         result["notes"].append(f"declared but not enforced: {', '.join(missing)}")
-        # The observation from #387: on gh-plumbing the only context that
-        # applied was the first declared one. Flag the pattern so a second
-        # sample either confirms it or kills it.
-        if declared and live and declared[0] in live and all(
-            c not in live for c in declared[1:]
-        ):
-            result["notes"].append(
-                "only the FIRST declared context is enforced -- matches the "
-                "gh-plumbing pattern"
-            )
     else:
         result["status"] = "ok"
     if extra:
@@ -226,6 +272,15 @@ def render(results: list[dict]) -> str:
                 lines.append(f"- declared: `{'`, `'.join(r['declared'])}`")
             if r.get("live"):
                 lines.append(f"- enforced: `{'`, `'.join(r['live'])}`")
+            if r.get("classic") is not None or r.get("ruleset"):
+                lines.append(
+                    f"  - via classic protection: "
+                    f"{'`' + '`, `'.join(r['classic']) + '`' if r.get('classic') else '(none)'}"
+                )
+                lines.append(
+                    f"  - via ruleset: "
+                    f"{'`' + '`, `'.join(r['ruleset']) + '`' if r.get('ruleset') else '(none)'}"
+                )
             if r.get("restrictions"):
                 lines.append(
                     f"- `restrictions`: {r['restrictions']}, "


### PR DESCRIPTION
## Summary

The audit shipped in #407 read only classic branch protection. **GitHub enforces required checks through two independent mechanisms**, and the union of both is what actually gates a merge:

| Mechanism | Endpoint | Written by |
|---|---|---|
| classic branch protection | `/branches/{branch}/protection` | the Probot Settings App, from `.github/settings.yml` |
| repository and organisation rulesets | `/rules/branches/{branch}` | **not the Settings App** |

Reading only the first produced wrong answers in both directions.

Refs #387

## What the blind spot cost

**A false alarm on a correctly configured repository.** `nolte/claude-home-assistant` has *no* classic protection and a ruleset enforcing exactly its three declared contexts. The audit reported it as `unprotected, 3 declared, 0 enforced`. That is the most dangerous error an audit can make — it sends someone to "fix" a repository that is already right.

**A false finding on this repository.** `gh-plumbing` has a repository ruleset, `default-branch-protection`, enforcing `docs / MkDocs Build` and `static / Static CI Tests`. The audit reported `docs / MkDocs Build` as declared-but-not-enforced. It has been enforced all along.

**A hypothesis built on the artifact.** #407 flagged a pattern — "only the first declared context is enforced" — and I recorded it on #387 as a new lead worth a second sample. It was an artifact of not reading rulesets. The heuristic is removed.

## Corrected numbers

| | before | after |
|---|---|---|
| repositories not enforcing what they declare | 4 of 20 | **3 of 20** |
| `gh-plumbing` enforced contexts | 1 of 3 | **2 of 3** |
| `claude-home-assistant` | "unprotected" | **fully protected, by ruleset** |

The one genuinely unenforced context on `gh-plumbing` is `actionlint / Workflow Lint` from #406, absent from both mechanisms.

## Changes

- The ruleset read is hoisted **above** the classic-protection early return, so a repository with no classic protection is no longer reported as unprotected before rulesets are consulted. That ordering was the actual defect behind the false alarm.
- Enforcement is reported per mechanism, so a reader can see *which* one covers a context — the difference between "the Settings App works" and "something else is covering for it".
- The "first declared context" heuristic is gone.
- A `403` on the rulesets endpoint degrades to a note rather than silently under-reporting enforcement.

## Testing

Run against the live portfolio; the numbers above are its output. Exit codes re-verified: `0` for `claude-home-assistant` (protected by ruleset), `1` for `gh-plumbing` (genuine drift).

## Risk / rollout notes

**Issue:** #387 · **Classification:** `bug` — the tool reported enforced protection as absent and absent protection as enforced.
**Specialist:** no matching specialised agent — generalist remediation.

**This changes what #387 is about.** The issue's candidate causes assumed one mechanism and asked why the Settings App drops contexts. With rulesets in view, the sharper question is **why two sources of truth exist at all**: `.github/settings.yml` declares contexts, a ruleset enforces a different set, and nothing reconciles them. On `gh-plumbing` the ruleset is the one that carries `docs / MkDocs Build`; the repository also ships a `terraform/` tree, so the ruleset may well have a second owner.

**Still real after the correction:** `claude-shared` is missing `links` and reports `enforce_admins: false` while extending commons that declare it true, and `claude-reachy-mini` has neither mechanism enforcing anything despite declaring three contexts.

**Rollback:** revert; the audit returns to classic-protection-only and its false alarm.
