### PR TITLE
fix(workflows): pin the two toolchain references #400 missed

### DIFF
--- a/.github/workflows/reusable-pre-commit.yaml
+++ b/.github/workflows/reusable-pre-commit.yaml
@@ -18,6 +18,12 @@ jobs:
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: '3.x'
+          # Concrete rather than '3.x', matching the other reusables and
+          # .tool-versions. This workflow sits behind `static / Static CI Tests`,
+          # which is the one required check most consumers enforce, so a
+          # floating interpreter here can turn a green pipeline red with no
+          # commit behind it. #400 pinned the input defaults elsewhere and
+          # missed this hardcoded one.
+          python-version: '3.14'
 
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/reusable-sphinx.yaml
+++ b/.github/workflows/reusable-sphinx.yaml
@@ -43,8 +43,12 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # Version-pinned rather than unbounded: continuous-integration §C
+          # forbids an unbounded range in a pipeline definition, and an
+          # unpinned tox is exactly how a green pipeline turns red without a
+          # commit. Renovate bumps these as reviewable pull requests.
           python -m pip install --upgrade pip
-          pip install tox tox-gh-actions
+          pip install 'tox==4.58.0' 'tox-gh-actions==3.5.0'
 
       - name: Test with tox
         run: tox -e ${{ inputs.scenario-name }}


### PR DESCRIPTION
## Summary

#400 pinned the floating toolchain references that #393 listed — and missed two of the four. **I closed #393 stating that item was complete.** It was not.

Refs #393

## What was missed

`reusable-pre-commit.yaml` still set `python-version: '3.x'`, hardcoded in the step rather than as an input default. #393's text named it explicitly: *"`python-version: "3.x"` — `reusable-mkdocs-build.yaml:10`, `reusable-python-coverage.yaml:10`, `reusable-mkdocs.yaml:30`; **hardcoded in `reusable-pre-commit.yaml:16`**"*. The patch matched on `default: "3.x"` and therefore skipped it.

`reusable-sphinx.yaml` still ran `pip install tox tox-gh-actions`, unbounded.

## How it surfaced

Not by re-reading the diff — by bumping a real consumer. `nolte/taskfiles#38` moved to `v2.0.0`, and its `static / Static CI Tests` log reads:

```text
python-version: 3.x
Successfully set up CPython (3.14.6)
```

It resolves to 3.14 today, which is why nothing looked wrong. That is the failure mode a floating reference has: correct until it isn't, with no commit in between.

**This one matters more than the others.** `reusable-pre-commit` sits behind `static / Static CI Tests`, which is the single required check most consumers actually enforce (#387). A floating interpreter there can turn every consumer's pipeline red with nothing to point at.

## Changes

- `reusable-pre-commit.yaml`: `'3.x'` → `'3.14'`, matching the other reusables and `.tool-versions`.
- `reusable-sphinx.yaml`: `tox` and `tox-gh-actions` pinned to `4.58.0` and `3.5.0`.

**The versions were looked up, not guessed.** My first draft pinned `tox==4.31.0` / `tox-gh-actions==3.4.0` from memory; PyPI reports `4.58.0` and `3.5.0`. Pinning to a version that merely exists would have been worse than leaving it unpinned — it would look deliberate while silently downgrading.

## Testing

- `grep` over `.github/workflows/` for `3.x` and `lts/*`: only the explanatory comments remain, no active references.
- `actionlint` clean, `pre-commit` green.
- The `reusable-pre-commit` change is exercised by this pull request's own `static / Static CI Tests`, since this repository dog-foods it through a local path reference (#405).

`reusable-sphinx` has no caller in this repository or the portfolio, so its pin is unverified at runtime.

## Risk / rollout notes

**Issue:** #393 — the toolchain item, incompletely delivered by #400
**Classification:** `bug` — a stated-complete item that was not.
**Specialist:** `nolte-shared:cicd-pipeline-design`.

**Consumer impact.** Any consumer calling `reusable-pre-commit` moves from "whatever `3.x` resolves to" to Python 3.14 explicitly. Today those are the same; the point is that they stay the same next month. A consumer needing an older interpreter for its hooks has no input to override this — `reusable-pre-commit` does not expose one, which is worth revisiting if it ever bites.

**Process note.** #393 was closed on a checklist I did not verify item by item against the tree. The other five items in that batch were checked; this one was taken from the commit message. Two of four sub-points of a single checkbox is exactly what a per-item verification would have caught.

**Rollback:** revert; the floating references return.
